### PR TITLE
fix: dynamic navbar logo, version routing and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { API_ROUTES } from "./lib/api-routes";
 
 interface VersionItem {
   id: string;
+  slug: string;
   version_number: string;
   status: "active" | "archived" | "draft";
   is_current: boolean;
@@ -34,22 +35,32 @@ function App() {
   const items = data?.data?.items?.filter((v) => v.status !== "draft") ?? [];
 
   const currentItem = items.find((v) => v.is_current);
-  const latestVersion = currentItem ? toRouteVersion(currentItem.version_number) : LATEST_VERSION;
-  const oldVersions = items
-    .filter((v) => !v.is_current)
-    .map((v) => toRouteVersion(v.version_number))
-    .filter((v, i, arr) => arr.indexOf(v) === i);
+  const latestRouteVersion = currentItem ? toRouteVersion(currentItem.version_number) : LATEST_VERSION;
+  const latestSlug = currentItem?.slug ?? LATEST_VERSION;
+
+  const oldItems = items.filter((v) => !v.is_current);
 
   return (
     <Routes>
-      {oldVersions.map((version) => (
-        <Route
-          key={version}
-          path={`/${version}/*`}
-          element={<ClientRouter version={version} />}
-        />
-      ))}
-      <Route path="/*" element={<ClientRouter version={latestVersion} />} />
+      {oldItems.map((item) => {
+        const routeVersion = toRouteVersion(item.version_number);
+        return (
+          <Route
+            key={routeVersion}
+            path={`/${routeVersion}/*`}
+            element={<ClientRouter version={routeVersion} slug={item.slug} isLatest={false} latestVersion={latestRouteVersion} />}
+          />
+        );
+      })}
+      {/* Also match the current version by its slug/routeVersion (e.g. /v9/*) */}
+      <Route
+        path={`/${latestRouteVersion}/*`}
+        element={<ClientRouter version={latestRouteVersion} slug={latestSlug} isLatest={true} latestVersion={latestRouteVersion} />}
+      />
+      <Route
+        path="/*"
+        element={<ClientRouter version={latestRouteVersion} slug={latestSlug} isLatest={true} latestVersion={latestRouteVersion} />}
+      />
     </Routes>
   );
 }

--- a/src/client/layouts/headers/Logo/Logo2.tsx
+++ b/src/client/layouts/headers/Logo/Logo2.tsx
@@ -4,6 +4,7 @@ import { cn } from "../../../../shared/utils/cn";
 interface Logo2Props {
   className?: string;
   size?: "sm" | "md" | "lg";
+  src?: string | null;
 }
 
 const SIZE_CLASS: Record<NonNullable<Logo2Props["size"]>, string> = {
@@ -12,10 +13,10 @@ const SIZE_CLASS: Record<NonNullable<Logo2Props["size"]>, string> = {
   lg: "h-10 sm:h-12 lg:h-14",
 };
 
-export default function Logo2({ className, size = "md" }: Logo2Props) {
+export default function Logo2({ className, size = "md", src }: Logo2Props) {
   return (
     <img
-      src={logo2}
+      src={src ?? logo2}
       alt="logo"
       className={cn("object-contain w-auto", SIZE_CLASS[size], className)}
     />

--- a/src/client/layouts/headers/Navbar.tsx
+++ b/src/client/layouts/headers/Navbar.tsx
@@ -5,11 +5,13 @@ import Logo2 from "./Logo/Logo2";
 import { Menu, X } from "lucide-react";
 import SectionContainer from "../../components/sectionContainer";
 import { useVersion } from "../../routes/VersionContext";
+import { useHome } from "../../pages/home/useHome";
 
 const Navbar = () => {
   const { getPath } = useVersion();
   const navigate = useNavigate();
   const [toggle, setToggle] = useState(false);
+  const { data: logo } = useHome((d) => d.edition.logoPath ?? d.edition.logo);
 
   const pages = [
     { path: "/", label: "Home" },
@@ -28,7 +30,7 @@ const Navbar = () => {
         className="flex items-center justify-between h-full w-full !py-0"
       >
         <div className="hover:cursor-pointer" onClick={() => navigate("/")}>
-          <Logo2 />
+          <Logo2 src={logo} />
         </div>
 
         <div className="sm:hidden">

--- a/src/client/pages/home/types.ts
+++ b/src/client/pages/home/types.ts
@@ -10,6 +10,8 @@ export interface Edition {
   slug: string;
   name: string;
   isCurrent: boolean;
+  logo?: string | null;
+  logoPath?: string | null;
   startDate?: string | null;
   endDate?: string | null;
 }

--- a/src/client/pages/home/useHome.ts
+++ b/src/client/pages/home/useHome.ts
@@ -26,14 +26,14 @@ interface Envelope<T> {
 }
 
 export function useHome<T = HomeContent>(select?: (d: HomeContent) => T) {
-  const { version, isLatest } = useVersion();
+  const { slug, isLatest } = useVersion();
 
   const path = isLatest
     ? API_ROUTES.homeContent
-    : API_ROUTES.homeContentBySlug.replace("${slug}", encodeURIComponent(version));
+    : API_ROUTES.homeContentBySlug.replace("${slug}", encodeURIComponent(slug));
 
   return useQuery({
-    queryKey: ["home", isLatest ? "current" : version],
+    queryKey: ["home", isLatest ? "current" : slug],
     queryFn: async () => {
       const res = await ictClient.get<Envelope<HomeContent>>(path);
       return res.data;

--- a/src/client/routes/ClientRouter.tsx
+++ b/src/client/routes/ClientRouter.tsx
@@ -15,14 +15,17 @@ import ContactUs from "../pages/contact-us/ContactUs";
 
 interface ClientRouterProps {
   version: string;
+  slug: string;
+  isLatest: boolean;
+  latestVersion: string;
 }
 
-export default function ClientRouter({ version }: ClientRouterProps) {
+export default function ClientRouter({ version, slug, isLatest, latestVersion }: ClientRouterProps) {
 
 
 
   return (
-    <VersionProvider version={version}>
+    <VersionProvider version={version} slug={slug} isLatest={isLatest} latestVersion={latestVersion}>
       <Routes>
         <Route element={<PageLayout />}>
           <Route index element={<HomePage />} />

--- a/src/client/routes/VersionContext.tsx
+++ b/src/client/routes/VersionContext.tsx
@@ -1,10 +1,10 @@
 // routes/VersionContext.tsx
 import { createContext, useContext } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { LATEST_VERSION } from "./route-type";
 
 interface VersionContextType {
   version: string;
+  slug: string;
   isLatest: boolean;
   getPath: (path: string) => string;
   navigateToVersion: (newVersion: string) => void;
@@ -14,13 +14,15 @@ const VersionContext = createContext<VersionContextType | null>(null);
 
 interface ProviderProps {
   version: string;
+  slug: string;
+  isLatest: boolean;
+  latestVersion: string;
   children: React.ReactNode;
 }
 
-export function VersionProvider({ version, children }: ProviderProps) {
+export function VersionProvider({ version, slug, isLatest, latestVersion, children }: ProviderProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const isLatest = version === LATEST_VERSION;
 
   // Generate correct path based on version
   const getPath = (path: string): string => {
@@ -43,7 +45,7 @@ export function VersionProvider({ version, children }: ProviderProps) {
     }
 
     // Navigate to same page in new version
-    if (newVersion === LATEST_VERSION) {
+    if (newVersion === latestVersion) {
       navigate(currentPage);
     } else {
       navigate(`/${newVersion}${currentPage}`);
@@ -56,6 +58,7 @@ export function VersionProvider({ version, children }: ProviderProps) {
     <VersionContext.Provider
       value={{
         version,
+        slug,
         isLatest,
         getPath,
         navigateToVersion,


### PR DESCRIPTION
## Summary
- Navbar logo is now fetched from `edition.logoPath` (server path) with fallback to `edition.logo` (Cloudinary URL) then the static asset — changes per active version
- Decouple URL route key (`v8`) from API slug (`ict-meetup-2025`) by threading `slug` and `isLatest` as props through `ClientRouter` → `VersionProvider` → `useHome`, fixing wrong content loading on old version routes
- Register current version by its route key so `/v9/` (or whichever is current) renders correctly instead of blank
- Pass `latestVersion` to `VersionProvider` so `navigateToVersion` works without the hardcoded `LATEST_VERSION` constant

## Test plan
- [ ] `/` loads current version content with its logo in navbar
- [ ] `/v8/` loads ICT Meetup 2025 content with its own logo — not the current version's data
- [ ] Version switcher navigates between versions without `LATEST_VERSION is not defined` error
- [ ] `/v9/` (current version slug) renders the home page correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)