### PR TITLE
Frontend UI fixes: navbar pinning, mobile menu, hero CTAs, highlights…

### DIFF
--- a/src/client/components/card.tsx
+++ b/src/client/components/card.tsx
@@ -21,7 +21,7 @@ const Card = ({ item, eventId, registerLink, className, ...rest }: CardProps) =>
   return (
     <div
       className={cn(
-        "rounded-3xl border border-black/5 bg-[#FEFEFE] p-4 group h-full font-sans w-[280px] mx-auto sm:w-[280px] md:w-auto shadow-[0_2px_8px_rgba(15,23,42,0.06),0_8px_18px_rgba(15,23,42,0.08)] transition-shadow duration-300 hover:shadow-[0_4px_12px_rgba(15,23,42,0.08),0_14px_28px_rgba(15,23,42,0.12)]",
+        "flex flex-col rounded-3xl border border-black/5 bg-[#FEFEFE] p-4 group h-full font-sans w-[280px] mx-auto sm:w-[280px] md:w-auto shadow-[0_2px_8px_rgba(15,23,42,0.06),0_8px_18px_rgba(15,23,42,0.08)] transition-shadow duration-300 hover:shadow-[0_4px_12px_rgba(15,23,42,0.08),0_14px_28px_rgba(15,23,42,0.12)]",
         className,
       )}
       {...rest}
@@ -37,41 +37,58 @@ const Card = ({ item, eventId, registerLink, className, ...rest }: CardProps) =>
         </div>
       </div>
 
-      <div className="mt-3">
-        <h3 className="text-[20px] font-semibold mb-1 truncate">{item.title}</h3>
-        <p className="text-[12px] mb-2 truncate" title={item.speaker}>
-          {item.speaker}
-        </p>
+      <div className="mt-3 flex flex-col flex-1">
+        <h3
+          className="text-[20px] font-semibold mb-1 truncate"
+          title={item.title}
+        >
+          {item.title}
+        </h3>
+        {/* Speaker line: hard-coded "with" + comma-separated names. Rendered
+            only when there is at least one speaker. */}
+        {item.speaker ? (
+          <p className="text-[12px] mb-2 truncate" title={`with ${item.speaker}`}>
+            with {item.speaker}
+          </p>
+        ) : null}
 
-        <div className="flex -space-x-3 mb-6">
-          {item.avatar.map((av, i) => (
-            <div
-              key={i}
-              className={`${i == 0 ? "bg-[#2dDBDB] rounded-full" : "bg-[#1CCECE] rounded-full"}`}
-            >
-              <img src={getImageUrl(av)} alt="Speaker" className="w-8 h-8 rounded-full " />
-            </div>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-2 gap-y-4 gap-x-2  mb-8">
-          <div className="flex items-center gap-2">
-            <Calendar className="w-4 h-4 " />
-            <span className="text-[12px] font-medium">{item.date}</span>
+        {item.avatar.length > 0 && (
+          <div className="flex -space-x-3 mb-4">
+            {item.avatar.map((av, i) => (
+              <div
+                key={i}
+                className={`${i == 0 ? "bg-[#2dDBDB] rounded-full" : "bg-[#1CCECE] rounded-full"}`}
+              >
+                <img src={getImageUrl(av)} alt="Speaker" className="w-8 h-8 rounded-full " />
+              </div>
+            ))}
           </div>
-          <div className="flex items-center gap-2">
-            <Banknote className="w-4 h-4  text-[#10B981] " />
-            <span className="text-[#10B981] text-[12px] font-medium">
-              Rs. {item.price}
+        )}
+
+        {/* mt-auto pins the info grid + button to the bottom so buttons align
+            across cards regardless of how much text is above. Each cell
+            truncates to one line so a long location can't blow up the height
+            or shrink the icon. */}
+        <div className="grid grid-cols-2 gap-y-4 gap-x-2 mt-auto pt-4 mb-6">
+          <div className="flex items-center gap-2 min-w-0">
+            <Calendar className="w-4 h-4 shrink-0" />
+            <span className="text-[12px] font-medium truncate">{item.date}</span>
+          </div>
+          <div className="flex items-center gap-2 min-w-0">
+            <Banknote className="w-4 h-4 text-[#10B981] shrink-0" />
+            <span className="text-[#10B981] text-[12px] font-medium truncate">
+              {item.price > 0 ? `Rs. ${item.price}` : "Free"}
             </span>
           </div>
-          <div className="flex items-center gap-2">
-            <Clock className="w-4 h-4  " />
-            <span className="text-[12px] font-medium">{item.time}</span>
+          <div className="flex items-center gap-2 min-w-0">
+            <Clock className="w-4 h-4 shrink-0" />
+            <span className="text-[12px] font-medium truncate">{item.time}</span>
           </div>
-          <div className="flex items-center gap-2 font-medium">
-            <MapPin className="w-4 h-4  " />
-            <span className="text-[12px] font-medium">{item.place}</span>
+          <div className="flex items-center gap-2 min-w-0 font-medium">
+            <MapPin className="w-4 h-4 shrink-0" />
+            <span className="text-[12px] font-medium truncate" title={item.place}>
+              {item.place}
+            </span>
           </div>
         </div>
 

--- a/src/client/components/event-card-format.ts
+++ b/src/client/components/event-card-format.ts
@@ -3,6 +3,8 @@
  * and the home hero (HighlightSection) so they render time and seats the same way.
  */
 
+import type { ContentType } from "../pages/home/sections/highlight-section/types";
+
 /** "10:00:00" | "10:00" → "10:00 AM"; returns "" for empty and echoes unknown formats. */
 export function formatEventTime(value: string | null | undefined): string {
   if (!value) return "";
@@ -37,4 +39,50 @@ export function remainingSeats(input: {
   bookedSeats: number;
 }): number {
   return Math.max(input.totalSeats - input.bookedSeats, 0);
+}
+
+/**
+ * Minimal event shape the Card needs. Both `ApiEvent` (events page) and
+ * `HighlightItem` (home page) structurally satisfy this, so a single mapper
+ * feeds the same Card in both places.
+ */
+export interface EventCardSource {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  date: string | null;
+  startTime: string | null;
+  endTime: string | null;
+  location: string;
+  fee: string;
+  totalSeats: number;
+  bookedSeats: number;
+  speakers?: { id: string; name: string; imageUrl: string | null }[] | null;
+}
+
+/**
+ * Maps a raw event to the Card's `ContentType`. This is the single source of
+ * truth for how an event becomes a card — the home events section and the
+ * events page both call it so their cards are identical.
+ */
+export function toEventCardItem(event: EventCardSource): ContentType {
+  return {
+    id: event.id,
+    image: event.imageUrl ?? "",
+    title: event.title,
+    // "with <names>" is assembled in the Card; here we just join speaker names.
+    speaker: (event.speakers ?? [])
+      .map((speaker) => speaker.name)
+      .filter(Boolean)
+      .join(", "),
+    avatar: (event.speakers ?? [])
+      .map((speaker) => speaker.imageUrl)
+      .filter((url): url is string => Boolean(url)),
+    date: event.date ?? "",
+    price: Number(event.fee) || 0,
+    time: formatEventTimeRange(event.startTime, event.endTime),
+    place: event.location,
+    seats: remainingSeats(event),
+    totalSeats: event.totalSeats,
+  };
 }

--- a/src/client/components/section-header.tsx
+++ b/src/client/components/section-header.tsx
@@ -37,7 +37,11 @@ export default function SectionHeader({
     <div className={cn("w-full flex", alignStyles[align], className)}>
       <h2
         className={cn(
-          " text-[40px] md:text-[60px] font-[650] tracking-[-2.4px] w-fit ",
+          // Mobile size stays below the hero title (34px) so the hero remains
+          // the largest text on the page; desktop is unchanged. Mobile tracking
+          // is a middle value — the -2.4px desktop tracking is too cramped at
+          // 30px, but 0 reads too loose.
+          " text-[30px] md:text-[60px] font-[650] tracking-[-1px] md:tracking-[-2.4px] w-fit ",
           reversePosition ? "flex gap-2 flex-row-reverse" : "",
           varientStyles[varient || "primary"],
         )}

--- a/src/client/components/sectionContainer.tsx
+++ b/src/client/components/sectionContainer.tsx
@@ -22,7 +22,12 @@ const SectionContainer = React.forwardRef<HTMLDivElement, PageLayoutProps>(
         case "full":
           return "w-full max-w-screen-2xl mx-auto ";
         case "container":
-          return "max-w-7xl mx-auto px-4 sm:px-6 lg:px-12 my-[60px] md:my-[120px] lg:my-[160px] xl:my-[180px]";
+          // Vertical spacing for every section — PADDING only (no margins),
+          // identical across all sections so the rhythm is consistent on mobile
+          // and desktop. Bottom padding is deliberately larger than the top to
+          // give each section more breathing room before the next. Full-bleed
+          // sections (Highlight/Gallery) mirror this `pb` on their own root.
+          return "max-w-7xl mx-auto px-4 sm:px-6 lg:px-12 pt-16 pb-28 md:pt-24 md:pb-40";
       }
     }
 

--- a/src/client/hooks/use-versions.ts
+++ b/src/client/hooks/use-versions.ts
@@ -1,0 +1,39 @@
+/**
+ * Route-version keys (e.g. ["v8", "v7", "v7.5"]) for every published edition,
+ * newest first. Falls back to the static VERSIONS list until the request
+ * resolves. Shared by the desktop version rail (VersionNavigate) and the
+ * mobile hamburger menu (Navbar) so both always show the same editions instead
+ * of a hardcoded list.
+ */
+import { useApiQuery } from "../../lib";
+import { VERSIONS } from "../routes/route-type";
+
+interface VersionItem {
+  id: string;
+  version_number: string;
+  status: "active" | "archived" | "draft";
+}
+
+interface VersionsResponse {
+  status: string;
+  data: { items: VersionItem[] };
+}
+
+/** Converts API version_number to route key: "8.0" → "v8", "7.5" → "v7.5" */
+function toRouteVersion(versionNumber: string): string {
+  const n = parseFloat(versionNumber);
+  return `v${n % 1 === 0 ? Math.floor(n) : n}`;
+}
+
+export function useVersions(): string[] {
+  const { data } = useApiQuery("versions")<VersionsResponse>({
+    queryParams: { limit: 50 },
+  });
+
+  return data?.data?.items
+    ? data.data.items
+        .filter((v) => v.status !== "draft")
+        .map((v) => toRouteVersion(v.version_number))
+        .filter((v, i, arr) => arr.indexOf(v) === i) // deduplicate
+    : VERSIONS;
+}

--- a/src/client/layouts/PageLayout.tsx
+++ b/src/client/layouts/PageLayout.tsx
@@ -10,7 +10,7 @@ export default function PageLayout() {
     <div className="app-layout">
       <ScrollToTop />
       <Navbar />
-      <main>
+      <main className="overflow-x-clip">
         <VersionNavigate />
         <Outlet />
       </main>

--- a/src/client/layouts/footer/Footer.tsx
+++ b/src/client/layouts/footer/Footer.tsx
@@ -7,6 +7,7 @@ import PrimeCollege from "../../../assets/PrimeCollege.svg";
 import SectionContainer from "../../components/sectionContainer";
 import { useVersion } from "../../routes/VersionContext";
 import { useSiteSettings } from "../../hooks/use-site-settings";
+import { useHome } from "../../pages/home/useHome";
 
 export const Footer = () => {
   const navigate = useNavigate();
@@ -15,6 +16,10 @@ export const Footer = () => {
   const editionLabel = version.toUpperCase();
 
   const { data: siteSettings } = useSiteSettings();
+  // Same edition logo the navbar shows, instead of a hard-coded bundled asset.
+  const { data: logo, isLoading: logoLoading } = useHome(
+    (d) => d.edition.logoPath ?? d.edition.logo,
+  );
 
   const clubEmail = siteSettings?.clubEmail || "itclub.prime@prime.edu.np";
   const clubPhone = siteSettings?.clubPhoneNumber || "+123 45 6 789";
@@ -51,7 +56,12 @@ export const Footer = () => {
             onClick={() => navigate(getPath("/"))}
           >
             <div className="flex flex-col items-center lg:items-start w-[164px]">
-              <Logo2 size="lg" className="h-9 sm:h-11 md:h-16 lg:h-20" />
+              <Logo2
+                size="lg"
+                src={logo}
+                loading={logoLoading}
+                className="h-9 sm:h-11 md:h-16 lg:h-20"
+              />
               {/* <p className="mt-2 text-lg font-semibold font-mona bg-gradient-to-r from-[#DBF5FF] to-[#51A7FF] bg-clip-text text-transparent text-center lg:text-left">
                 Fusion Of Tech Talent & Creativity
               </p> */}
@@ -219,13 +229,17 @@ export const Footer = () => {
       <div className="mt-9 border-[0.8px] border-[#353535]"></div>
 
       <div className="flex flex-col items-center w-full gap-6 lg:flex-row lg:justify-between mt-9 lg:gap-0">
-        <nav className="flex flex-wrap justify-center w-full gap-4 font-sans text-md font-semibold lg:justify-start lg:gap-8 lg:text-lg lg:w-auto">
+        <nav className="flex flex-wrap justify-center w-full gap-4 font-sans text-md lg:justify-start lg:gap-8 lg:text-lg lg:w-auto">
           {pages.map(({ label, path }) => (
             <NavLink
               key={`${label}-${path}`}
               to={getPath(path)}
               className={({ isActive }) =>
-                isActive ? "text-blue-400" : "hover:text-blue-400"
+                `transition-colors duration-300 ${
+                  isActive
+                    ? "text-nav-active font-semibold"
+                    : "text-nav-default hover:text-nav-hover font-normal"
+                }`
               }
             >
               {label}

--- a/src/client/layouts/headers/Logo/Logo2.tsx
+++ b/src/client/layouts/headers/Logo/Logo2.tsx
@@ -6,6 +6,12 @@ interface Logo2Props {
   className?: string;
   size?: "sm" | "md" | "lg";
   src?: string | null;
+  /**
+   * When true, the edition logo hasn't resolved yet. We render an invisible,
+   * space-reserving placeholder instead of the bundled fallback so the real
+   * logo doesn't flash a different image on reload.
+   */
+  loading?: boolean;
 }
 
 const SIZE_CLASS: Record<NonNullable<Logo2Props["size"]>, string> = {
@@ -14,7 +20,15 @@ const SIZE_CLASS: Record<NonNullable<Logo2Props["size"]>, string> = {
   lg: "h-10 sm:h-12 lg:h-14",
 };
 
-export default function Logo2({ className, size = "md", src }: Logo2Props) {
+export default function Logo2({ className, size = "md", src, loading }: Logo2Props) {
+  if (loading) {
+    return (
+      <div
+        aria-hidden
+        className={cn("w-[120px] max-w-full", SIZE_CLASS[size], className)}
+      />
+    );
+  }
   return (
     <img
       src={src ? getImageUrl(src) : logo2}

--- a/src/client/layouts/headers/Navbar.tsx
+++ b/src/client/layouts/headers/Navbar.tsx
@@ -1,23 +1,62 @@
 import { NavLink, useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import Logo2 from "./Logo/Logo2";
 import { Menu, X } from "lucide-react";
 import SectionContainer from "../../components/sectionContainer";
 import { useVersion } from "../../routes/VersionContext";
+import { useVersions } from "../../hooks/use-versions";
 import { useHome } from "../../pages/home/useHome";
 import { useEventsList } from "../../pages/event/useEvents";
 
 const Navbar = () => {
-  const { getPath } = useVersion();
+  const { getPath, navigateToVersion, version } = useVersion();
   const navigate = useNavigate();
   const [toggle, setToggle] = useState(false);
-  const { data: logo } = useHome((d) => d.edition.logoPath ?? d.edition.logo);
+  const { data: logo, isLoading: logoLoading } = useHome(
+    (d) => d.edition.logoPath ?? d.edition.logo,
+  );
   const { events, isLoading: eventsLoading } = useEventsList();
+  const versions = useVersions();
 
   // Only surface the Events link when this edition actually has events.
   // Keep it while loading to avoid a flash, hide it once confirmed empty.
   const hasEvents = eventsLoading || events.length > 0;
+
+  // Lock page scroll while the mobile menu is open. Freezing the body with
+  // position:fixed (instead of overflow:hidden) works on iOS Safari AND keeps
+  // overflow rules off <body> — an overflow there clips the backdrop-blurred
+  // fixed header in Chromium (the vanishing-navbar bug). The saved scrollY is
+  // restored on close so the page doesn't jump to the top.
+  useEffect(() => {
+    if (!toggle) return;
+
+    // If the viewport grows past the sm breakpoint (menu is display:none
+    // there), close it so the scroll lock doesn't linger on desktop.
+    const mq = window.matchMedia("(min-width: 640px)");
+    const onBreakpointChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setToggle(false);
+    };
+    mq.addEventListener("change", onBreakpointChange);
+
+    const scrollY = window.scrollY;
+    const { style } = document.body;
+    style.position = "fixed";
+    style.top = `-${scrollY}px`;
+    style.left = "0";
+    style.right = "0";
+    style.width = "100%";
+
+    return () => {
+      mq.removeEventListener("change", onBreakpointChange);
+      style.position = "";
+      style.top = "";
+      style.left = "";
+      style.right = "";
+      style.width = "";
+      window.scrollTo(0, scrollY);
+    };
+  }, [toggle]);
 
   const pages = [
     { path: "/", label: "Home" },
@@ -27,98 +66,143 @@ const Navbar = () => {
     { path: "/contacts", label: "Contacts" },
   ];
 
-  const versions = ["V8", "V7", "V6", "V5"];
-
   return (
-    <header className="sticky top-0 z-50 w-full h-[63px] bg-primary transition-all duration-300">
-      <SectionContainer
-        width="navbar"
-        className="flex items-center justify-between h-full w-full !py-0"
+    <>
+      {/*
+        `fixed` (not `sticky`): sticky kept failing on scroll-down because an
+        ancestor became a scroll/clip container. Fixed positioning pins the bar
+        to the viewport unconditionally, in both scroll directions. The spacer
+        div below reserves the 63px the bar no longer occupies in flow.
+      */}
+      {/*
+        While the mobile menu is open the bar darkens to near-solid so it reads
+        as one dark surface with the menu overlay below it — at 70% over a
+        bright section the bar looked washed-out against the black menu.
+      */}
+      <header
+        className={`fixed top-0 inset-x-0 z-50 w-full h-[63px] backdrop-blur-md border-b border-white/10 transition-all duration-300 ${
+          toggle ? "bg-[#010005]/95" : "bg-[#010005]/70"
+        }`}
       >
-        <div className="hover:cursor-pointer" onClick={() => navigate(getPath("/"))}>
-          <Logo2 src={logo} />
-        </div>
+        <SectionContainer
+          width="navbar"
+          className="flex items-center justify-between h-full w-full !py-0"
+        >
+          <div className="hover:cursor-pointer" onClick={() => navigate(getPath("/"))}>
+            <Logo2 src={logo} loading={logoLoading} />
+          </div>
 
-        <div className="sm:hidden">
-          <button
-            onClick={() => setToggle(!toggle)}
-            className="p-2 text-white relative z-50"
-          >
-            {toggle ? <X size={28} /> : <Menu size={28} />}
-          </button>
-
-          {toggle && (
-            <>
-              <div
-                className="fixed inset-0 bg-black/20 z-30"
-                onClick={() => setToggle(false)}
-              />
-
-              <div className="fixed inset-x-4  top-[74px] bg-[#02091966]/40 backdrop-blur-md border border-white/20 rounded-[28px] py-10 px-6 z-40 shadow-[0_25px_50px_-12px_rgba(0,0,0,0.5)] flex flex-col items-center overflow-y-auto max-h-[80vh]">
-                <div className="flex flex-col items-center gap-8 text-lg font-medium tracking-wide w-full">
-                  {pages.map(({ label, path }) => (
-                    <NavLink
-                      key={`${label}-${path}`}
-                      className={({ isActive }) =>
-                        `transition-colors duration-300 ${
-                          isActive
-                            ? "text-nav-active font-semibold"
-                            : "text-nav-default hover:text-nav-hover"
-                        }`
-                      }
-                      to={getPath(path)}
-                      end={path === "/"}
-                      onClick={() => setToggle(false)}
-                    >
-                      {label}
-                    </NavLink>
-                  ))}
-                </div>
-
-                <div className="w-full h-[1px] bg-gradient-to-r from-transparent via-white/30 to-transparent my-8" />
-
-                <div className="flex flex-col items-center w-full">
-                  <h3 className="bg-gradient-to-b from-[#DBF5FF] to-[#51A7FF] bg-clip-text text-transparent font-semibold text-xl mb-6 tracking-wide">
-                    Versions
-                  </h3>
-                   <div className="flex flex-col items-center gap-6 text-base font-normal text-gray-400">
-                    {versions.map((v) => (
-                         <NavLink
-                        key={v}
-                        to={`/${v.toLowerCase()}`}
-                        className="hover:text-white transition-colors duration-300"
-                        onClick={() => setToggle(false)}
-                      >
-                        {v}
-                      </NavLink>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </>
-          )}
-        </div>
-
-        <nav className="hidden gap-8 text-xl sm:flex">
-          {pages.map(({ label, path }) => (
-            <NavLink
-              key={`${label}-${path}`}
-              to={getPath(path)}
-              end={path === "/"}
-              className={({ isActive }) =>
-                `transition-colors duration-300 ${
-                  isActive
-                    ? "text-nav-active font-semibold"
-                    : "text-nav-default hover:text-nav-hover"
-                }`
-              }
+          <div className="sm:hidden">
+            <button
+              onClick={() => setToggle(!toggle)}
+              className="p-2 text-white relative z-50"
             >
-              {label}
-            </NavLink>
-          ))}
-        </nav>
-      </SectionContainer>
-    </header>
+              {toggle ? <X size={28} /> : <Menu size={28} />}
+            </button>
+          </div>
+
+          {/* Matches the footer nav: same font size (text-md → lg:text-lg),
+              hover = secondary accent (nav-hover), active = primary accent
+              (nav-active) and stays bold; inactive items are regular weight. */}
+          <nav className="hidden gap-8 font-sans text-md lg:text-lg sm:flex">
+            {pages.map(({ label, path }) => (
+              <NavLink
+                key={`${label}-${path}`}
+                to={getPath(path)}
+                end={path === "/"}
+                className={({ isActive }) =>
+                  `transition-colors duration-300 ${
+                    isActive
+                      ? "text-nav-active font-semibold"
+                      : "text-nav-default hover:text-nav-hover font-normal"
+                  }`
+                }
+              >
+                {label}
+              </NavLink>
+            ))}
+          </nav>
+        </SectionContainer>
+      </header>
+
+      {/* Flow spacer: the fixed header is out of normal flow, so this keeps
+          page content starting 63px down exactly like the old sticky bar. */}
+      <div aria-hidden="true" className="h-[63px]" />
+
+      {/*
+        Full-screen mobile menu. Rendered OUTSIDE <header> on purpose: the header
+        uses backdrop-blur (a backdrop-filter), which makes it the containing
+        block for any fixed descendant — a fixed child there gets clipped to the
+        63px bar instead of covering the viewport (that was the crop/glitch). As
+        a sibling it fills the screen and scrolls, so every item is reachable. It
+        sits below the sticky header (z-40 < z-50) so the logo + close button
+        stay on top and tappable.
+      */}
+      {toggle && (
+        /*
+          Outer div = the scroll container only. It starts BELOW the fixed
+          63px header (top-[63px]) so the bar + close button stay visible.
+          Centering happens on the INNER wrapper via min-h-full +
+          justify-center: when the content is shorter than the viewport it is
+          perfectly centered, and when it's taller the wrapper simply grows and
+          scrolls. (Putting justify-center + overflow-y-auto on the SAME
+          element clipped the top items — that was the off-center glitch.)
+        */
+        /* Semi-transparent frosted overlay (not flat black): the page shows
+           faintly through the blur, and its tone matches the darkened bar so
+           bar + menu read as one continuous dark glass surface. */
+        <div className="fixed inset-x-0 top-[63px] bottom-0 z-40 bg-[#010005]/85 backdrop-blur-lg sm:hidden overflow-y-auto">
+          <div className="min-h-full flex flex-col items-center justify-center gap-4 py-10 px-6">
+          <div className="flex flex-col items-center gap-10 font-sans text-3xl tracking-wide w-full">
+            {pages.map(({ label, path }) => (
+              <NavLink
+                key={`${label}-${path}`}
+                className={({ isActive }) =>
+                  `transition-colors duration-300 ${
+                    isActive
+                      ? "text-nav-active font-semibold"
+                      : "text-nav-default hover:text-nav-hover font-normal"
+                  }`
+                }
+                to={getPath(path)}
+                end={path === "/"}
+                onClick={() => setToggle(false)}
+              >
+                {label}
+              </NavLink>
+            ))}
+          </div>
+
+          <div className="w-full h-[1px] bg-gradient-to-r from-transparent via-white/30 to-transparent my-10" />
+
+          <div className="flex flex-col items-center w-full">
+            <h3 className="bg-gradient-to-b from-[#DBF5FF] to-[#51A7FF] bg-clip-text text-transparent font-semibold text-2xl mb-6 tracking-wide">
+              Versions
+            </h3>
+            <div className="flex flex-col items-center gap-6 text-lg font-normal text-gray-400">
+              {versions.map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  className={`uppercase transition-colors duration-300 ${
+                    version === v
+                      ? "text-white font-semibold"
+                      : "hover:text-white"
+                  }`}
+                  onClick={() => {
+                    navigateToVersion(v);
+                    setToggle(false);
+                  }}
+                >
+                  {v}
+                </button>
+              ))}
+            </div>
+          </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/client/layouts/version-navigate/VersionNavigate.tsx
+++ b/src/client/layouts/version-navigate/VersionNavigate.tsx
@@ -1,39 +1,12 @@
-import { VERSIONS } from "../../routes/route-type";
 import { cn } from "../../../shared/utils/cn";
 import "../../../App.css";
 import { useVersion } from "../../routes/VersionContext";
-import { useApiQuery } from "../../../lib/use-api-query";
-
-interface VersionItem {
-  id: string;
-  version_number: string;
-  status: "active" | "archived" | "draft";
-}
-
-interface VersionsResponse {
-  status: string;
-  data: { items: VersionItem[] };
-}
-
-/** Converts API version_number to route key: "8.0" → "v8", "7.5" → "v7.5" */
-function toRouteVersion(versionNumber: string): string {
-  const n = parseFloat(versionNumber);
-  return `v${n % 1 === 0 ? Math.floor(n) : n}`;
-}
+import { useVersions } from "../../hooks/use-versions";
 
 export default function VersionNavigate() {
   const { navigateToVersion, version } = useVersion();
 
-  const { data } = useApiQuery("versions")<VersionsResponse>({
-    queryParams: { limit: 50 },
-  });
-
-  const versions: string[] = data?.data?.items
-    ? data.data.items
-        .filter((v) => v.status !== "draft")
-        .map((v) => toRouteVersion(v.version_number))
-        .filter((v, i, arr) => arr.indexOf(v) === i) // deduplicate
-    : VERSIONS;
+  const versions = useVersions();
 
   const MAX_VISIBLE = 5;
   const ITEM_HEIGHT = 28; // px, matches button height (py-1 + text-sm line-height)

--- a/src/client/pages/event/EventPage.tsx
+++ b/src/client/pages/event/EventPage.tsx
@@ -13,11 +13,14 @@ export default function EventsPage() {
   const categoryIdParam = activeCategoryId === "all" ? undefined : activeCategoryId;
   const { events, isLoading: eventsLoading } = useEventsList(categoryIdParam);
 
+  // The top swiper is a "highlights" banner — only highlighted events belong there.
+  const highlightedEvents = events.filter((e) => e.isHighlighted);
+
   return (
     <div className="overflow-x-hidden min-h-screen bg-[#F2F5FA] pb-4">
-      <EventSwiper events={events} />
+      <EventSwiper events={highlightedEvents} />
       <div className="bg-[#F2F5FA] text-black">
-        <div className="mx-auto max-w-7xl px-4 py-2 sm:py-16 md:space-y-10 space-y-12">
+        <div className="mx-auto max-w-7xl px-4 py-2 sm:pt-6 sm:pb-16 md:space-y-10 space-y-12">
           <CategoryTabs
             categories={categories}
             activeCategoryId={activeCategoryId}

--- a/src/client/pages/event/components/CategoryTabs.tsx
+++ b/src/client/pages/event/components/CategoryTabs.tsx
@@ -7,6 +7,8 @@ interface CategoryTabsProps {
   activeCategoryId: string;
   onSelect: (id: string) => void;
   isLoading?: boolean;
+  /** Horizontal alignment of the tabs. Defaults to "center". */
+  align?: "start" | "center";
 }
 
 const CategoryTabs = ({
@@ -14,6 +16,7 @@ const CategoryTabs = ({
   activeCategoryId,
   onSelect,
   isLoading,
+  align = "center",
 }: CategoryTabsProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -30,9 +33,13 @@ const CategoryTabs = ({
   if (isLoading) return null;
 
   return (
-    <div className="mt-0 sm:mt-20 mb-12 px-1 sm:px-4">
+    <div className="mt-0 mb-8 sm:mb-12 px-1 sm:px-4">
       {/* --- MOBILE DROPDOWN --- */}
-      <div className="md:hidden relative mx-auto max-w-[300px] sm:max-w-none">
+      <div
+        className={`md:hidden relative max-w-[300px] sm:max-w-none ${
+          align === "start" ? "mr-auto" : "mx-auto"
+        }`}
+      >
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="w-full h-[34px] bg-[#3571F0] hover:bg-[#184EBF] text-white px-4 rounded-full flex items-center justify-between transition-colors duration-200 text-sm font-semibold shadow-md"
@@ -72,7 +79,11 @@ const CategoryTabs = ({
       </div>
 
       {/* --- DESKTOP TABS --- */}
-      <div className="hidden md:flex flex-wrap gap-x-12 gap-y-6 text-xl justify-center font-bold pb-4">
+      <div
+        className={`hidden md:flex flex-wrap gap-x-12 gap-y-6 text-xl font-bold pb-4 ${
+          align === "start" ? "justify-start" : "justify-center"
+        }`}
+      >
         {options.map((opt) => (
           <button
             key={opt.id}

--- a/src/client/pages/event/components/EventGrid.tsx
+++ b/src/client/pages/event/components/EventGrid.tsx
@@ -1,35 +1,13 @@
 import { useNavigate } from "react-router-dom";
 import { useVersion } from "../../../routes/VersionContext";
 import Card from "../../../components/card";
-import {
-  formatEventTimeRange,
-  remainingSeats,
-} from "../../../components/event-card-format";
+import { toEventCardItem } from "../../../components/event-card-format";
 import type { ApiEvent } from "../useEvents";
-import type { ContentType } from "../types";
 import { slugify } from "../../../../lib";
 
 interface EventGridProps {
   events: ApiEvent[];
   isLoading?: boolean;
-}
-
-function toCardItem(event: ApiEvent): ContentType {
-  return {
-    id: event.id,
-    image: event.imageUrl ?? "",
-    title: event.title,
-    speaker: event.subtitle ?? "",
-    avatar: (event.speakers ?? [])
-      .map((speaker) => speaker.imageUrl)
-      .filter((url): url is string => Boolean(url)),
-    date: event.date ?? "",
-    price: Number(event.fee) || 0,
-    time: formatEventTimeRange(event.startTime, event.endTime),
-    place: event.location,
-    seats: remainingSeats(event),
-    totalSeats: event.totalSeats,
-  };
 }
 
 const EventGrid = ({ events, isLoading }: EventGridProps) => {
@@ -64,7 +42,7 @@ const EventGrid = ({ events, isLoading }: EventGridProps) => {
           className="cursor-pointer"
         >
           <Card
-            item={toCardItem(event)}
+            item={toEventCardItem(event)}
             eventId={event.id}
             registerLink={event.registerLink}
           />

--- a/src/client/pages/event/useEvents.ts
+++ b/src/client/pages/event/useEvents.ts
@@ -26,6 +26,8 @@ export interface ApiEvent {
   /** Approved registrations for this event; remaining = totalSeats − bookedSeats. */
   bookedSeats: number;
   status: string;
+  /** Whether this event is flagged as a highlight (top swiper on the events page). */
+  isHighlighted?: boolean;
   categoryId: string;
   category: EventCategory;
   speakers?: { id: string; name: string; imageUrl: string | null }[] | null;

--- a/src/client/pages/home/sections/about-section/AboutSection.tsx
+++ b/src/client/pages/home/sections/about-section/AboutSection.tsx
@@ -16,7 +16,7 @@ export const AboutSection = () => {
           backgroundColor: "#010005",
         }}
       >
-        <div className="relative z-10 flex flex-col lg:flex-row items-center gap-8 md:gap-6 lg:gap-16 xl:gap-20 mt-12 mb-48">
+        <div className="relative z-10 flex flex-col lg:flex-row items-center gap-8 md:gap-6 lg:gap-16 xl:gap-20">
           {/* Mobile Title */}
           <SectionHeader
             titleHighlight="This Year's"

--- a/src/client/pages/home/sections/about-section/components/AboutContent.tsx
+++ b/src/client/pages/home/sections/about-section/components/AboutContent.tsx
@@ -21,7 +21,7 @@ const AboutContent = () => {
         {/* `content` is sanitized HTML from the backend — rendered via RichText
             (DOMPurify) rather than as a plain string. */}
         <RichText
-          className="my-1 md:my-2 xl:my-2 space-y-4 text-[#DFDFDF]"
+          className="my-1 md:my-2 xl:my-2 space-y-4 text-left text-[#DFDFDF]"
           html={about?.content}
         />
       </div>

--- a/src/client/pages/home/sections/faq-section/FaqSection.tsx
+++ b/src/client/pages/home/sections/faq-section/FaqSection.tsx
@@ -20,27 +20,15 @@ const FAQSection = () => {
 
   return (
     <SectionContainer className="mx-auto px-4 sm:px-6 space-y-12">
-      {/* Mobile: short title */}
-      <div className="block sm:hidden">
-        <SectionHeader
-          titleNormal=""
-          titleHighlight="FAQs"
-          varient="primary"
-          align="center"
-          className="mb-4"
-        />
-      </div>
-
-      {/* Desktop: full title */}
-      <div className="hidden sm:block">
-        <SectionHeader
-          titleNormal="Frequently"
-          titleHighlight="Asked Questions"
-          varient="primary"
-          align="center"
-          className="mb-4"
-        />
-      </div>
+      {/* Same full title on every breakpoint (mobile used to abbreviate to
+          "FAQs"); at the 30px mobile size it simply wraps, centered. */}
+      <SectionHeader
+        titleNormal="Frequently"
+        titleHighlight="Asked Questions"
+        varient="primary"
+        align="center"
+        className="mb-4"
+      />
 
       {/* FAQ List */}
       <div className="flex flex-col gap-4 max-w-4xl mx-auto">

--- a/src/client/pages/home/sections/gallery-section/GallerySection.tsx
+++ b/src/client/pages/home/sections/gallery-section/GallerySection.tsx
@@ -27,13 +27,23 @@ const GallerySection = () => {
   const sectionRef = useRef<HTMLDivElement>(null);
 
   const scrollToSection = () => {
-    sectionRef.current?.scrollIntoView({ behavior: "smooth" });
+    const el = sectionRef.current;
+    if (!el) return;
+    // Offset by the sticky navbar height (h-[63px]) so the section's top edge
+    // lands just below the navbar instead of scrolling underneath it.
+    const NAVBAR_HEIGHT = 63;
+    const top = el.getBoundingClientRect().top + window.scrollY - NAVBAR_HEIGHT;
+    window.scrollTo({ top, behavior: "smooth" });
   };
+
+  // Gallery images carry per-image links (set in the admin). The "View More"
+  // button opens the first available link in a new tab.
+  const viewMoreLink = gallery.find((g) => g.link)?.link ?? null;
 
   if (!gallery.length) return null;
 
   return (
-    <div ref={sectionRef} className="w-full py-24 bg-white relative">
+    <div ref={sectionRef} className="w-full pt-16 pb-28 md:pt-24 md:pb-40 bg-white relative">
       <button
         className="absolute -top-5 left-[50%] transform -translate-x-1/2 z-56 cursor-pointer bg-white rounded-full p-2 drop-shadow-xl"
         onClick={scrollToSection}
@@ -76,7 +86,16 @@ const GallerySection = () => {
         </div>
 
         <div className="flex justify-center mt-16">
-          <Button label="View More" rightIcon={<ChevronRight size={18} />} />
+          <Button
+            label="View More"
+            rightIcon={<ChevronRight size={18} />}
+            disabled={!viewMoreLink}
+            onClick={() => {
+              if (viewMoreLink) {
+                window.open(viewMoreLink, "_blank", "noopener,noreferrer");
+              }
+            }}
+          />
         </div>
       </div>
     </div>

--- a/src/client/pages/home/sections/highlight-section/HighlightSection.tsx
+++ b/src/client/pages/home/sections/highlight-section/HighlightSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay, Navigation, Pagination } from "swiper/modules";
@@ -10,71 +10,40 @@ import "swiper/css/navigation";
 
 import SectionHeader from "../../../../components/section-header";
 import Card from "../../../../components/card";
-import {
-  formatEventTimeRange,
-  remainingSeats,
-} from "../../../../components/event-card-format";
+import { toEventCardItem } from "../../../../components/event-card-format";
 import SvgIcon from "../../../../components/icon/svgIcon";
-import CategoryTabs from "../../../event/components/CategoryTabs";
-import { useEventCategories } from "../../../event/useEvents";
 import { Button } from "../../../../../shared/design-components";
 import NavButton from "./components/NavButton";
 import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { useHome } from "../../useHome";
 import { useVersion } from "../../../../routes/VersionContext";
-import type { ContentType } from "./types";
 import { slugify } from "../../../../../lib";
 
 export default function HighlightSection() {
-  const [activeCategoryId, setActiveCategoryId] = useState<string>("all");
   const sectionRef = useRef<HTMLDivElement>(null);
 
   const { data: highlights = [] } = useHome((d) => d.sections.highlights);
-  const { categories, isLoading: categoriesLoading } = useEventCategories();
-
-  // TODO(mapping): Card's ContentType diverges from the Event entity. Confirmed
-  // fields are wired; the rest are placeholders pending your confirmation:
-  //  - speaker line uses `subtitle`; avatars aren't on the aggregate yet (left empty).
-  //  - price is parsed from `fee` (a string) — confirm the fee format.
-  const cards: (ContentType & {
-    id: string;
-    registerLink: string | null;
-    categoryId: string;
-  })[] = highlights.map((e) => ({
-    id: e.id,
-    registerLink: e.registerLink ?? null,
-    categoryId: e.categoryId,
-    image: e.imageUrl ?? "",
-    title: e.title,
-    speaker: e.subtitle ?? "",
-    avatar: [],
-    date: e.date ?? "",
-    price: Number(e.fee) || 0,
-    time: formatEventTimeRange(e.startTime, e.endTime),
-    place: e.location,
-    seats: remainingSeats(e),
-    totalSeats: e.totalSeats,
-  }));
-
-  const visibleCards =
-    activeCategoryId === "all"
-      ? cards
-      : cards.filter((c) => c.categoryId === activeCategoryId);
 
   const scrollToSection = () => {
-    sectionRef.current?.scrollIntoView({ behavior: "smooth" });
+    const el = sectionRef.current;
+    if (!el) return;
+    // Offset by the sticky navbar height (h-[63px]) so the section's top edge
+    // lands just below the navbar instead of scrolling underneath it.
+    const NAVBAR_HEIGHT = 63;
+    const top = el.getBoundingClientRect().top + window.scrollY - NAVBAR_HEIGHT;
+    window.scrollTo({ top, behavior: "smooth" });
   };
 
   const navigate = useNavigate();
   const { getPath } = useVersion();
 
-  if (!cards.length) return null;
+  if (!highlights.length) return null;
 
   return (
     <div
       ref={sectionRef}
-      className=" bg-[#F2F5FA] text-black max-h-[848px] relative"
+      className=" bg-[#F2F5FA] text-black relative"
     >
       <button
         className="absolute -top-5 left-[50%] transform -translate-x-1/2 z-48 cursor-pointer bg-white rounded-full p-2 drop-shadow-xl "
@@ -83,22 +52,32 @@ export default function HighlightSection() {
         <SvgIcon />
       </button>
 
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-12 py-16 md:space-y-10 space-y-12">
-        {/* section header */}
-        <SectionHeader
-          titleNormal="Event"
-          titleHighlight="Overview"
-          varient="secondary"
-          className="justify-start"
-        />
-
-        {/* category tabs — dynamic + interactive, shared with the events page */}
-        <CategoryTabs
-          categories={categories}
-          activeCategoryId={activeCategoryId}
-          onSelect={setActiveCategoryId}
-          isLoading={categoriesLoading}
-        />
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-12 pt-16 pb-28 md:pt-24 md:pb-40 space-y-6">
+        {/* Section header, with "View more" on its own line directly below it.
+            Desktop only — on mobile the button moves below the swiper
+            pagination dots instead (see bottom of the section). */}
+        <div className="space-y-6">
+          <SectionHeader
+            titleNormal="Major"
+            titleHighlight="Highlights"
+            varient="secondary"
+            className="justify-center md:justify-start"
+          />
+          <div className="hidden md:flex justify-end">
+            <Link to={getPath("/events")}>
+              <Button
+                className="flex items-center justify-center whitespace-nowrap"
+                rightIcon={
+                  <div className="bg-[#3571F0] text-white px-1 py-1 rounded-full">
+                    <ArrowRight size={15} strokeWidth={2} />
+                  </div>
+                }
+                label="View more"
+                variant="ghost"
+              />
+            </Link>
+          </div>
+        </div>
 
         {/* swiper items */}
         <div className="relative space-y-8 md:space-y-8">
@@ -115,13 +94,7 @@ export default function HighlightSection() {
           </div>
 
           {/* swiper items */}
-          {visibleCards.length === 0 ? (
-            <p className="text-center text-gray-400 py-16">
-              No events in this category yet.
-            </p>
-          ) : (
           <Swiper
-            key={activeCategoryId}
             modules={[Navigation, Autoplay, Pagination]}
             spaceBetween={20}
             slidesPerView={1}
@@ -143,8 +116,11 @@ export default function HighlightSection() {
             }}
             className="pb-16"
           >
-            {visibleCards.map((item, index) => (
-              <SwiperSlide key={item.id} className="py-2">
+            {highlights.map((event, index) => (
+              // !h-auto lets the flex slides stretch to the tallest card so every
+              // card is the same height (same as the events-page grid), instead
+              // of each slide sizing to its own content.
+              <SwiperSlide key={event.id} className="!h-auto py-2">
                 {/*
                   Each card uses its loop index as a stagger delay (index * 0.1s),
                   so the row reveals left-to-right instead of all at once — that
@@ -153,6 +129,7 @@ export default function HighlightSection() {
                   whileHover lifts the card for a tactile response.
                 */}
                 <motion.div
+                  className="h-full"
                   initial={{ opacity: 0, y: 30 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, amount: 0.3 }}
@@ -161,31 +138,34 @@ export default function HighlightSection() {
                 >
                   <Card
                     className="hover:cursor-pointer "
-                    onClick={() => navigate(getPath(`/event-detail/${slugify(item.title)}`))}
-                    item={item}
-                    eventId={item.id}
-                    registerLink={item.registerLink}
+                    onClick={() => navigate(getPath(`/event-detail/${slugify(event.title)}`))}
+                    item={toEventCardItem(event)}
+                    eventId={event.id}
+                    registerLink={event.registerLink ?? null}
                   />
                 </motion.div>
               </SwiperSlide>
             ))}
           </Swiper>
-          )}
 
           <div className="custom-pagination flex justify-center lg:hidden mt-8 gap-2"></div>
+
+          {/* Mobile-only "View more": sits below the swiper pagination dots.
+              On md+ the button lives at the top right next to the header. */}
+          <div className="flex md:hidden justify-center">
             <Link to={getPath("/events")}>
-            <Button
-            className="flex items-center justify-center mx-auto"
-            rightIcon={
-              <div className="bg-[#3571F0] text-white px-1 py-1 rounded-full">
-                <ArrowRight size={15} strokeWidth={2} />
-              </div>
-            }
-            label="View more"
-            variant="ghost"
-          />
+              <Button
+                className="flex items-center justify-center whitespace-nowrap"
+                rightIcon={
+                  <div className="bg-[#3571F0] text-white px-1 py-1 rounded-full">
+                    <ArrowRight size={15} strokeWidth={2} />
+                  </div>
+                }
+                label="View more"
+                variant="ghost"
+              />
             </Link>
-          
+          </div>
         </div>
       </div>
     </div>

--- a/src/client/pages/home/sections/landing-section/LandingSection.tsx
+++ b/src/client/pages/home/sections/landing-section/LandingSection.tsx
@@ -32,52 +32,59 @@ export function LandingSection() {
   const dateLabel = formatEventDateRange(edition?.startDate, edition?.endDate);
 
   return (
-    <div className="landing_section relative w-full min-h-screen overflow-hidden pt-32 sm:pt-40">
+    <div className="landing_section relative w-full sm:min-h-screen pt-32 sm:pt-40 pb-[calc(32vw+56px)] sm:pb-0">
       {/*
-        Same position/size as before — we only animate opacity + filter
-        brightness so the arc "lights up" out of the dark. No transform/scale,
-        so layout is untouched.
+        Mobile: the hero used to force a full 100svh, but the arc is anchored to
+        the buttons and only fills the upper part — leaving a huge black gap
+        before the next section. Instead we let the section hug its content and
+        reserve just enough bottom space (scaled to the arc's width-driven
+        height) for the arc's visible masked area. Desktop keeps min-h-screen.
       */}
-      <figure className="pointer-events-none absolute -bottom-[240px] left-1/2 -translate-x-1/2 z-0 w-full">
-        <motion.img
-          src={image}
-          alt=""
-          className="w-full select-none"
-          initial={{ opacity: 0, filter: "brightness(0.15)" }}
-          animate={{ opacity: 1, filter: "brightness(1)" }}
-          transition={{ duration: 2.2, ease: "easeOut" }}
-        />
-      </figure>
-
       {/*
-        Content fades up slightly after the background starts glowing (delay),
-        so the eye lands on the arc first, then the copy resolves in.
+        Content + arc share this wrapper so the arc can anchor to the BUTTONS
+        (the wrapper's bottom edge) instead of the section bottom — that keeps
+        the arc the same distance below the buttons at every screen size. The
+        -mt nudges the whole hero up.
       */}
-      <motion.div
-        className="flex flex-col  space-y-4 relative z-20"
+      <div className="relative z-10 -mt-[60px]">
+        {/*
+          Content fades up slightly after the background starts glowing (delay),
+          so the eye lands on the arc first, then the copy resolves in.
+        */}
+        <motion.div
+          className="flex flex-col  space-y-4 relative z-20"
         initial={{ opacity: 0, y: 24 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.8, ease: "easeOut", delay: 0.6 }}
       >
         <div className="items-center flex justify-center text-center">
-          <div className="flex items-center gap-2 border-1 p-2 rounded-full  bg-white/5  ">
-            <div className="flex rounded-full bg-btn-primary text-[14px] py-[2px] px-[14px]">
-              Event on
+          <Link to={getPath("/events")}>
+            <div className="flex items-center gap-2 border-1 p-2 rounded-full  bg-white/5 transition-colors hover:bg-white/10 cursor-pointer">
+              <div className="flex rounded-full bg-btn-primary text-[14px] md:text-[16px] py-[2px] px-[14px]">
+                Event on
+              </div>
+              <div className="flex text-[14px] md:text-[16px] items-center gap-2 leading-3 font-normal -tracking-[0.598px]">
+                {dateLabel || "Coming Soon"}
+                <motion.span
+                  className="flex"
+                  animate={{ x: [0, 4, 0] }}
+                  transition={{ duration: 1.2, ease: "easeInOut", repeat: Infinity }}
+                >
+                  <ArrowRight size={20} />
+                </motion.span>
+              </div>{" "}
             </div>
-            <div className="flex text-[14px] items-center gap-2 leading-3 font-normal -tracking-[0.598px]">
-              {dateLabel || "Coming Soon"} <ArrowRight size={20} />{" "}
-            </div>{" "}
-          </div>
+          </Link>
         </div>
         <div className="relative flex flex-col gap-4 w-[100%] px-[1%]   sm:px-0 sm:w-[80%] md:w-[75%] lg:w-[70%] xl:w-[60%] 2xl:w-[52%] text-center mx-auto  ">
 
 
-          <div className="flex text-[34px] m-auto sm:text-[50px] sm:leading-[46px]  md:text-[64px] 2xl:text-[80px] font-[700] leading-[37px] px-3 md:leading-[73px] bg-gradient-to-r from-[#DBF5FF]  to-[#51A7FF] bg-clip-text text-transparent -tracking-[2px] ">
+          <div className="flex text-[34px] m-auto sm:text-[50px] sm:leading-[46px]  md:text-[64px] 2xl:text-[80px] font-[700] leading-[37px] px-3 pb-2 md:leading-[73px] bg-gradient-to-r from-[#DBF5FF]  to-[#51A7FF] bg-clip-text text-transparent -tracking-[2px] ">
             {hero?.heading}
           </div>
           <Text
             align="center"
-            className="flex px-5 mx-auto  sm:px-9 lg:px-20 my-3 text-[10px] sm:text-[16px]"
+            className="flex px-5 mx-auto  sm:px-9 lg:px-20 my-3 text-[14px] md:text-[16px]"
           >
             {hero?.paragraph}
           </Text>
@@ -88,25 +95,88 @@ export function LandingSection() {
         </div>
         <div className="flex sm:flex-row flex-col gap-4 sm:gap-10 items-center justify-center  pt-2 sm:pt-10">
           <Link to={getPath("/register")}>
-            <Button
-              variant="glass"
-              className="text-xs sm:text-base"
-              rightIcon={<ChevronRight />}
-              label="Register Now "
-            />
+            {/* Old glass button, but the whitish hover fill is kept ON always
+                (!bg-glow-secondary + black text) so Register Now stays the light
+                primary CTA. Wrapper scales up on hover only (no idle pulse). */}
+            <motion.div
+              className="inline-block"
+              whileHover={{ scale: 1.05 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            >
+              <Button
+                variant="glass"
+                className="!w-fit text-xs sm:text-base !bg-glow-secondary !text-black"
+                rightIcon={
+                  <motion.span
+                    className="flex"
+                    animate={{ x: [0, 4, 0] }}
+                    transition={{ duration: 1.2, ease: "easeInOut", repeat: Infinity }}
+                  >
+                    <ChevronRight />
+                  </motion.span>
+                }
+                label="Register Now "
+              />
+            </motion.div>
           </Link>
           <Link to={getPath("/sponsors")}>
-            <Button
-              variant="glass"
-              className="text-xs sm:text-base"
-              rightIcon={<ChevronRight />}
-              label="Be a Sponsor"
-            />
+            <motion.div
+              className="inline-block"
+              whileHover={{ scale: 1.05 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            >
+              <Button
+                variant="glass"
+                className="!w-fit text-xs sm:text-base"
+                rightIcon={
+                  <motion.span
+                    className="flex"
+                    animate={{ x: [0, 4, 0] }}
+                    transition={{ duration: 1.2, ease: "easeInOut", repeat: Infinity }}
+                  >
+                    <ChevronRight />
+                  </motion.span>
+                }
+                label="Be a Sponsor"
+              />
+            </motion.div>
           </Link>
         </div>
-      </motion.div>
+        </motion.div>
 
-      {/* <div className=" bg-transparent mx-auto w-1/2 blur-xs h-full backdrop:blur-xl  border-4 border-white rounded-full "></div> */}
+        {/*
+          Arc sits just below the buttons at the SAME gap on every screen size.
+          It is placed at the content's bottom edge (top-full) and lifted by 48%
+          of its height (where the bright burst sits in the PNG) minus a fixed
+          56px gap — the % tracks the image as it scales, the px is the constant
+          gap. The image is NOT clipped; it renders in full and a bottom mask
+          gradient (see the img style) fades its lower half into the page so the
+          glow dissolves smoothly instead of ending on a hard edge.
+        */}
+        <figure
+          className="pointer-events-none absolute top-full left-1/2 w-[140%] sm:w-full -z-10"
+          style={{ transform: "translate(-50%, calc(-48% + 56px))" }}
+        >
+          <motion.img
+            src={image}
+            alt=""
+            className="w-full select-none"
+            style={{
+              // Fade the lower half of the arc to true transparency so the glow
+              // dissolves into the page background instead of ending on a hard
+              // rectangular edge. Nothing is cropped now — the image renders in
+              // full and the mask does the blending.
+              maskImage:
+                "linear-gradient(to bottom, #000 0%, #000 48%, transparent 82%)",
+              WebkitMaskImage:
+                "linear-gradient(to bottom, #000 0%, #000 48%, transparent 82%)",
+            }}
+            initial={{ opacity: 0, filter: "brightness(0.15)" }}
+            animate={{ opacity: 1, filter: "brightness(1)" }}
+            transition={{ duration: 2.2, ease: "easeOut" }}
+          />
+        </figure>
+      </div>
     </div>
   );
 }

--- a/src/client/pages/home/sections/speaker-section/SpeakerSection.tsx
+++ b/src/client/pages/home/sections/speaker-section/SpeakerSection.tsx
@@ -1,51 +1,48 @@
 // SpeakerSection.tsx
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Pagination } from "swiper/modules";
+
+// Import Swiper styles
+import "swiper/css";
+import "swiper/css/pagination";
+
+import { motion } from "framer-motion";
 import SpeakerCard from "./SpeakerCard";
 import SectionHeader from "../../../../components/section-header";
 import SectionContainer from "../../../../components/sectionContainer";
-import { useState, useRef } from "react";
-import { motion } from "framer-motion";
+import useWindowBreakPoints from "../../../../hooks/CheckResponsive";
 import { useHome } from "../../useHome";
+import type { Speaker } from "../../types";
+
+// Shared card wrapper so the grid and the swiper get the identical
+// index-staggered reveal + hover lift.
+const AnimatedSpeakerCard = ({
+  speaker,
+  index,
+}: {
+  speaker: Speaker;
+  index: number;
+}) => (
+  <motion.div
+    className="h-full flex justify-center"
+    initial={{ opacity: 0, y: 30 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true, amount: 0.3 }}
+    whileHover={{ y: -8 }}
+    transition={{ duration: 0.3, ease: "easeOut", delay: index * 0.05 }}
+  >
+    <SpeakerCard speaker={speaker} />
+  </motion.div>
+);
 
 const SpeakerSection = () => {
-  const [activeIndex, setActiveIndex] = useState(0);
-  const [animating, setAnimating] = useState(false);
   const { data: speakers = [] } = useHome((d) => d.sections.speakers);
-  const totalCards = speakers.length;
+  const screen = useWindowBreakPoints();
 
-  const touchStartX = useRef<number>(0);
-  const touchEndX = useRef<number>(0);
-
-  const goTo = (index: number) => {
-    if (animating || index === activeIndex) return;
-    setAnimating(true);
-    setActiveIndex(index);
-    setTimeout(() => setAnimating(false), 300);
-  };
-
-  const handleTouchStart = (e: React.TouchEvent) => {
-    touchStartX.current = e.targetTouches[0].clientX;
-  };
-
-  const handleTouchMove = (e: React.TouchEvent) => {
-    touchEndX.current = e.targetTouches[0].clientX;
-  };
-
-  const handleTouchEnd = () => {
-    const diff = touchStartX.current - touchEndX.current;
-    if (Math.abs(diff) < 50) return;
-
-    if (diff > 0) {
-      goTo(Math.min(activeIndex + 1, totalCards - 1));
-    } else {
-      goTo(Math.max(activeIndex - 1, 0));
-    }
-  };
-
-  // Guard placed after all hooks (rules of hooks) — no speakers, no section.
   if (!speakers.length) return null;
 
   return (
-    <SectionContainer className="mx-auto text-center px-4 sm:px-6 space-y-14 my-20 sm:my-32">
+    <SectionContainer className="mx-auto text-center px-4 sm:px-6 space-y-14">
       <SectionHeader
         titleNormal="Joining Us This"
         titleHighlight="Edition"
@@ -54,59 +51,53 @@ const SpeakerSection = () => {
         className="mb-4"
       />
 
-      {/* Mobile Carousel */}
-      <div className="flex sm:hidden flex-col items-center gap-12">
-        {/* Swipeable card area */}
-        <div
-          className="w-full flex justify-center"
-          onTouchStart={handleTouchStart}
-          onTouchMove={handleTouchMove}
-          onTouchEnd={handleTouchEnd}
-        >
-          {/* No key prop — just opacity transition */}
-          <div
-            style={{ transition: "opacity 0.3s ease" }}
-            className={animating ? "opacity-0" : "opacity-100"}
-          >
-            {speakers[activeIndex] && (
-              <SpeakerCard speaker={speakers[activeIndex]} />
-            )}
-          </div>
-        </div>
-
-        {/* Dot indicators */}
-        <div className="flex justify-center gap-2">
-          {Array.from({ length: totalCards }).map((_, i) => (
-            <button
-              key={i}
-              onClick={() => goTo(i)}
-              className={`rounded-full transition-all duration-300 ${
-                i === activeIndex
-                  ? "w-2 h-2 bg-[#51A7FF]"
-                  : "w-2 h-2 bg-[#ADADAD]"
-              }`}
+      {screen === "desktop" ? (
+        // Desktop: static grid. Cards are a fixed 280px wide, so 4 columns only
+        // fit inside the max-w-7xl container from xl up; between lg and xl the
+        // grid falls back to 3 columns to avoid overlap (mirrors the old
+        // Swiper's 1300px breakpoint for 4 slides).
+        <div className="grid grid-cols-3 xl:grid-cols-4 gap-5 justify-items-center">
+          {speakers.map((speaker, index) => (
+            <AnimatedSpeakerCard
+              key={speaker.id}
+              speaker={speaker}
+              index={index}
             />
           ))}
         </div>
-      </div>
-
-      {/* Desktop Grid */}
-      <div className="hidden sm:grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6 md:gap-6 xl:gap-6 justify-items-center">
-        {speakers.map((speaker, i) => (
-          // Same index-staggered reveal as the event cards: each card delays by
-          // i * 0.08s so the grid populates in a wave. whileHover gives a lift.
-          <motion.div
-            key={speaker.id}
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.2 }}
-            whileHover={{ y: -8 }}
-            transition={{ duration: 0.3, ease: "easeOut", delay: i * 0.04 }}
+      ) : (
+        // Mobile/tablet: swiper with dot pagination (nav arrows were only ever
+        // shown on desktop, which now renders the grid instead).
+        <div className="relative">
+          <Swiper
+            modules={[Pagination]}
+            spaceBetween={20}
+            slidesPerView={1}
+            pagination={{ clickable: true, el: ".custom-pagination-speaker" }}
+            breakpoints={{
+              640: {
+                slidesPerView: 2,
+              },
+              860: {
+                slidesPerView: 3,
+              },
+            }}
+            className="pb-16"
           >
-            <SpeakerCard speaker={speaker} />
-          </motion.div>
-        ))}
-      </div>
+            {speakers.map((speaker, index) => (
+              // !h-auto lets slides stretch to equal height
+              <SwiperSlide
+                key={speaker.id}
+                className="!h-auto py-2 flex justify-center"
+              >
+                <AnimatedSpeakerCard speaker={speaker} index={index} />
+              </SwiperSlide>
+            ))}
+          </Swiper>
+
+          <div className="custom-pagination-speaker flex justify-center mt-8 gap-2"></div>
+        </div>
+      )}
     </SectionContainer>
   );
 };

--- a/src/client/pages/home/types.ts
+++ b/src/client/pages/home/types.ts
@@ -91,6 +91,8 @@ export interface HighlightItem {
   status: string;
   /** Category the event belongs to; drives the landing-page category tabs. */
   categoryId: string;
+  /** Speakers for this event; used for the "with <names>" line + avatars. */
+  speakers?: { id: string; name: string; imageUrl: string | null }[] | null;
   /** External registration URL; takes precedence over the in-app form. */
   registerLink: string | null;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -17,8 +17,49 @@
 
   body {
     @apply bg-primary text-primary font-sans;
-    overflow-x: hidden;
+    /* Do NOT put overflow-x on body/html: the navbar carries a backdrop-filter
+       (backdrop-blur), and a fixed/sticky element with its own backdrop-filter
+       gets CLIPPED by any non-visible-overflow ancestor in Chromium's
+       compositor — the bar vanished mid-scroll. Horizontal overflow (the wide
+       hero arc etc.) is clipped on <main> in PageLayout instead, which is not
+       an ancestor of the header. */
   }
+}
+
+/* Modern scrollbar — slim, rounded, dark-themed with a subtle blue accent.
+   WebKit (Chrome/Edge/Safari) uses the pseudo-elements; Firefox uses the
+   scrollbar-* properties. Applied globally so every scroll surface matches. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(53, 113, 240, 0.55) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  /* Accent color #3571F0 */
+  background-color: rgba(53, 113, 240, 0.5);
+  border-radius: 9999px;
+  /* Transparent border creates padding around the thumb so it reads as a
+     slim floating pill rather than a full-width bar. */
+  border: 2px solid transparent;
+  background-clip: content-box;
+  transition: background-color 0.2s ease;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(53, 113, 240, 0.85);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 @layer components {
@@ -66,4 +107,18 @@
 
 .react-datepicker__input-container input {
   @apply w-full;
+}
+
+/* Speaker section swiper dots sit on the near-black section background, where
+   Swiper's default translucent-dark bullets vanish. Force a greyish inactive
+   dot and a blue active dot so the indicator is always visible. */
+.custom-pagination-speaker .swiper-pagination-bullet {
+  width: 8px;
+  height: 8px;
+  background-color: #adadad;
+  opacity: 1;
+}
+
+.custom-pagination-speaker .swiper-pagination-bullet-active {
+  background-color: #51a7ff;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,9 +42,9 @@ export default {
         'primary': '#F5F5F5',      
         'secondary': '#D4D4D4',    
         'tertiary': '#A3A3A3',     
-        'nav-default': '#F5F5F5',  
-        'nav-hover': '#A3A3A3',    
-        'nav-active': '#3B82F6',   
+        'nav-default': '#F5F5F5',
+        'nav-hover': '#60A5FA',    // secondary accent — hover state
+        'nav-active': '#3B82F6',   // primary accent — active state
       },
       spacing: {
         'page-margin': '2rem',


### PR DESCRIPTION
…, FAQ

- Fix vanishing navbar: drop overflow-x clip from body (it clipped the backdrop-blurred fixed header in Chromium); clip horizontal overflow on <main> instead and pin the header with fixed + flow spacer
- Mobile hamburger menu: semi-transparent frosted overlay, bar darkens while open, proper vertical centering without clipped items, body scroll lock while open, auto-close past the sm breakpoint
- Hero CTAs scale on hover only instead of idle pulsing
- Highlights: "View more" stays top-right on desktop, moves below the swiper pagination dots on mobile
- FAQ: single "Frequently Asked Questions" title on all breakpoints
- Assorted section/component polish (events grid, gallery, speakers, footer, version navigation)