### PR TITLE
Home page and events page UI fixes

### DIFF
--- a/src/client/components/bg-content.tsx
+++ b/src/client/components/bg-content.tsx
@@ -6,12 +6,15 @@ interface ByContentProps {
   position?: "relative" | "absolute";
   children?: React.ReactNode;
   className?: string;
+  /** Extra classes for the gradient banner itself (e.g. to hide it on mobile). */
+  bannerClassName?: string;
 }
 
 const TopBgContent = ({
   position = "relative",
   children,
   className,
+  bannerClassName,
 }: ByContentProps): React.ReactNode => {
   const child = children as React.ReactNode;
 
@@ -21,7 +24,10 @@ const TopBgContent = ({
         style={{
           background: `linear-gradient(180deg, #020919 12.28%, #3571F0 209.51%)`,
         }}
-        className={`${position}  h-[250px] md:h-[300px] w-full flex items-center`}
+        className={cn(
+          `${position} h-[250px] md:h-[300px] w-full flex items-center`,
+          bannerClassName
+        )}
       >
         <SectionContainer as="div" key={"eventPage"} className="w-full">
           {position === "relative" && child}

--- a/src/client/hooks/use-versions.ts
+++ b/src/client/hooks/use-versions.ts
@@ -1,12 +1,12 @@
 /**
  * Route-version keys (e.g. ["v8", "v7", "v7.5"]) for every published edition,
- * newest first. Falls back to the static VERSIONS list until the request
- * resolves. Shared by the desktop version rail (VersionNavigate) and the
- * mobile hamburger menu (Navbar) so both always show the same editions instead
- * of a hardcoded list.
+ * newest first. Returns [] until the request resolves (and when the backend
+ * has no published editions) — callers hide their version UI when the list is
+ * empty rather than showing a stale hardcoded fallback. Shared by the desktop
+ * version rail (VersionNavigate) and the mobile hamburger menu (Navbar) so
+ * both always show the same editions.
  */
 import { useApiQuery } from "../../lib";
-import { VERSIONS } from "../routes/route-type";
 
 interface VersionItem {
   id: string;
@@ -35,5 +35,5 @@ export function useVersions(): string[] {
         .filter((v) => v.status !== "draft")
         .map((v) => toRouteVersion(v.version_number))
         .filter((v, i, arr) => arr.indexOf(v) === i) // deduplicate
-    : VERSIONS;
+    : [];
 }

--- a/src/client/layouts/headers/Navbar.tsx
+++ b/src/client/layouts/headers/Navbar.tsx
@@ -173,32 +173,38 @@ const Navbar = () => {
             ))}
           </div>
 
-          <div className="w-full h-[1px] bg-gradient-to-r from-transparent via-white/30 to-transparent my-10" />
+          {/* Hidden entirely when there are no published editions — matches
+              the desktop rail, which also renders nothing in that case. */}
+          {versions.length > 0 && (
+            <>
+              <div className="w-full h-[1px] bg-gradient-to-r from-transparent via-white/30 to-transparent my-10" />
 
-          <div className="flex flex-col items-center w-full">
-            <h3 className="bg-gradient-to-b from-[#DBF5FF] to-[#51A7FF] bg-clip-text text-transparent font-semibold text-2xl mb-6 tracking-wide">
-              Versions
-            </h3>
-            <div className="flex flex-col items-center gap-6 text-lg font-normal text-gray-400">
-              {versions.map((v) => (
-                <button
-                  key={v}
-                  type="button"
-                  className={`uppercase transition-colors duration-300 ${
-                    version === v
-                      ? "text-white font-semibold"
-                      : "hover:text-white"
-                  }`}
-                  onClick={() => {
-                    navigateToVersion(v);
-                    setToggle(false);
-                  }}
-                >
-                  {v}
-                </button>
-              ))}
-            </div>
-          </div>
+              <div className="flex flex-col items-center w-full">
+                <h3 className="bg-gradient-to-b from-[#DBF5FF] to-[#51A7FF] bg-clip-text text-transparent font-semibold text-2xl mb-6 tracking-wide">
+                  Versions
+                </h3>
+                <div className="flex flex-col items-center gap-6 text-lg font-normal text-gray-400">
+                  {versions.map((v) => (
+                    <button
+                      key={v}
+                      type="button"
+                      className={`uppercase transition-colors duration-300 ${
+                        version === v
+                          ? "text-white font-semibold"
+                          : "hover:text-white"
+                      }`}
+                      onClick={() => {
+                        navigateToVersion(v);
+                        setToggle(false);
+                      }}
+                    >
+                      {v}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
           </div>
         </div>
       )}

--- a/src/client/layouts/version-navigate/VersionNavigate.tsx
+++ b/src/client/layouts/version-navigate/VersionNavigate.tsx
@@ -14,6 +14,9 @@ export default function VersionNavigate() {
   const maxHeight =
     MAX_VISIBLE * ITEM_HEIGHT + (MAX_VISIBLE - 1) * GAP;
 
+  // No published editions (or still loading) — don't render an empty rail.
+  if (!versions.length) return null;
+
   return (
     <div className="fixed  right-4 md:right-8 top-1/2 -translate-y-1/2 z-50 rounded-full py-4 px-2 hidden sm:flex flex-col gap-2 backblur-lg overflow-hidden bg-[#040F264D]">
       <div className="glass-specular"></div>

--- a/src/client/pages/event/EventPage.tsx
+++ b/src/client/pages/event/EventPage.tsx
@@ -6,38 +6,54 @@ import { ArrowRight } from "lucide-react";
 import Button from "../../../shared/design-components/button/Button";
 import { useEventCategories, useEventsList } from "./useEvents";
 
+const PAGE_SIZE = 10;
+
 export default function EventsPage() {
   const [activeCategoryId, setActiveCategoryId] = useState<string>("all");
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const { categories, isLoading: categoriesLoading } = useEventCategories();
   const categoryIdParam = activeCategoryId === "all" ? undefined : activeCategoryId;
   const { events, isLoading: eventsLoading } = useEventsList(categoryIdParam);
+  // The highlights banner is universal: it always shows every highlighted
+  // event, regardless of the selected category tab, so it reads from the
+  // unfiltered list. React Query dedupes this with the "All" tab's query.
+  const { events: allEvents } = useEventsList();
 
-  // The top swiper is a "highlights" banner — only highlighted events belong there.
-  const highlightedEvents = events.filter((e) => e.isHighlighted);
+  const handleCategorySelect = (id: string) => {
+    setActiveCategoryId(id);
+    setVisibleCount(PAGE_SIZE);
+  };
+
+  const highlightedEvents = allEvents.filter((e) => e.isHighlighted);
+  const visibleEvents = events.slice(0, visibleCount);
+  const hasMore = events.length > visibleCount;
 
   return (
-    <div className="overflow-x-hidden min-h-screen bg-[#F2F5FA] pb-4">
+    <div className="overflow-x-hidden min-h-screen bg-[#F2F5FA] pb-12 md:pb-16">
       <EventSwiper events={highlightedEvents} />
       <div className="bg-[#F2F5FA] text-black">
-        <div className="mx-auto max-w-7xl px-4 py-2 sm:pt-6 sm:pb-16 md:space-y-10 space-y-12">
+        <div className="mx-auto max-w-7xl px-4 pt-2 pb-10 sm:pt-12 sm:pb-24 md:space-y-10 space-y-12">
           <CategoryTabs
             categories={categories}
             activeCategoryId={activeCategoryId}
-            onSelect={setActiveCategoryId}
+            onSelect={handleCategorySelect}
             isLoading={categoriesLoading}
           />
-          <EventGrid events={events} isLoading={eventsLoading} />
-          <Button
-            className="flex items-center justify-center mx-auto md:hidden"
-            rightIcon={
-              <div className="bg-[#3571F0] text-white px-1 py-1 rounded-full">
-                <ArrowRight size={15} strokeWidth={2} />
-              </div>
-            }
-            label="Load More"
-            variant="ghost"
-          />
+          <EventGrid events={visibleEvents} isLoading={eventsLoading} />
+          {hasMore && (
+            <Button
+              className="flex items-center justify-center mx-auto"
+              onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+              rightIcon={
+                <div className="bg-[#3571F0] text-white px-1 py-1 rounded-full">
+                  <ArrowRight size={15} strokeWidth={2} />
+                </div>
+              }
+              label="Load More"
+              variant="ghost"
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/client/pages/event/components/CategoryTabs.tsx
+++ b/src/client/pages/event/components/CategoryTabs.tsx
@@ -33,7 +33,7 @@ const CategoryTabs = ({
   if (isLoading) return null;
 
   return (
-    <div className="mt-0 mb-8 sm:mb-12 px-1 sm:px-4">
+    <div className="mt-0 px-1 sm:px-4">
       {/* --- MOBILE DROPDOWN --- */}
       <div
         className={`md:hidden relative max-w-[300px] sm:max-w-none ${
@@ -80,7 +80,7 @@ const CategoryTabs = ({
 
       {/* --- DESKTOP TABS --- */}
       <div
-        className={`hidden md:flex flex-wrap gap-x-12 gap-y-6 text-xl font-bold pb-4 ${
+        className={`hidden md:flex flex-wrap gap-x-12 gap-y-6 text-xl font-bold ${
           align === "start" ? "justify-start" : "justify-center"
         }`}
       >

--- a/src/client/pages/event/components/EventSwiper.tsx
+++ b/src/client/pages/event/components/EventSwiper.tsx
@@ -9,20 +9,26 @@ import "swiper/css/navigation";
 import "swiper/css/pagination";
 import "swiper/css";
 
+import { useNavigate } from "react-router-dom";
+
 import TopBgContent from "../../../components/bg-content";
 import type { ApiEvent } from "../useEvents";
 import { getImageUrl } from "../../../../lib/imageUtils";
+import { useVersion } from "../../../routes/VersionContext";
+import { slugify } from "../../../../lib";
 
 interface EventSwiperProps {
   events: ApiEvent[];
 }
 
 const EventSwiper = ({ events }: EventSwiperProps) => {
+  const navigate = useNavigate();
+  const { getPath } = useVersion();
   const slides = events.filter((e) => e.imageUrl);
 
   return (
-    <TopBgContent position="absolute">
-      <div className="max-w-[1200px] mx-auto px-0 sm:px-4 pt-0 sm:pt-16 min-h-[500px] flex items-center justify-center">
+    <TopBgContent position="absolute" bannerClassName="hidden md:flex">
+      <div className="max-w-[1200px] mx-auto px-0 sm:px-4 pt-0 md:pt-16 md:min-h-[500px] flex items-center justify-center">
         {slides.length === 0 ? null : (
           <Swiper
             modules={[Pagination, EffectCoverflow, Autoplay, Navigation]}
@@ -38,18 +44,21 @@ const EventSwiper = ({ events }: EventSwiperProps) => {
             autoplay={{ delay: 4000, disableOnInteraction: false }}
             loop={slides.length > 1}
             pagination={{ clickable: true, dynamicBullets: false }}
-            className="events-swiper-3d !pb-16 overflow-visible w-full"
+            className="events-swiper-3d !pb-8 md:!pb-16 overflow-visible w-full"
           >
             {slides.map((event) => (
               <SwiperSlide
                 key={event.id}
-                className="relative bg-transparent rounded-t rounded-b-lg sm:rounded-3xl overflow-hidden group shadow-xl"
+                className="relative bg-transparent rounded-none md:rounded-3xl overflow-hidden group shadow-xl cursor-pointer"
+                onClick={() =>
+                  navigate(getPath(`/event-detail/${slugify(event.title)}`))
+                }
               >
                 <div className="overflow-hidden h-[240px] md:h-[515px]">
                   <img
                     src={getImageUrl(event.imageUrl)}
                     alt={event.title}
-                    className="w-full h-full object-cover block rounded-t-lg image-reflect transition-transform duration-500 group-hover:scale-105"
+                    className="w-full h-full object-cover block md:rounded-t-lg image-reflect transition-transform duration-500 group-hover:scale-105"
                   />
                 </div>
               </SwiperSlide>

--- a/src/client/pages/event/useEvents.ts
+++ b/src/client/pages/event/useEvents.ts
@@ -79,8 +79,19 @@ export function useEventsList(categoryId?: string) {
     enabled: !!versionId,
   });
 
+  // "All" mixes every category, so order by the category's displayOrder first
+  // (workshop → competition → session, etc.). The sort is stable, so within a
+  // category the backend's own ordering is preserved. For a single-category
+  // query all keys are equal and the list is untouched.
+  const items = data?.data?.items ?? [];
+  const events = [...items].sort(
+    (a, b) =>
+      (a.category?.displayOrder ?? Number.MAX_SAFE_INTEGER) -
+      (b.category?.displayOrder ?? Number.MAX_SAFE_INTEGER),
+  );
+
   return {
-    events: data?.data?.items ?? [],
+    events,
     isLoading,
   };
 }

--- a/src/client/pages/home/sections/gallery-section/GallerySection.tsx
+++ b/src/client/pages/home/sections/gallery-section/GallerySection.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import useWindowBreakPoints from "../../../../hooks/CheckResponsive";
-import { ChevronRight } from "lucide-react";
+import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react";
 import { useRef } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import SvgIcon from "../../../../components/icon/svgIcon";
 import SectionHeader from "../../../../components/section-header";
 import GalleryCard from "./components/GalleryCard";
@@ -11,6 +12,7 @@ import { GALLERY_POSITIONS } from "./data";
 import type { ScreenSize } from "./types";
 import { Button } from "../../../../../shared/design-components";
 import { useHome } from "../../useHome";
+import { getImageUrl } from "../../../../../lib/imageUtils";
 
 const GallerySection = () => {
   const [selected, setSelected] = useState<number | null>(null);
@@ -39,6 +41,43 @@ const GallerySection = () => {
   // Gallery images carry per-image links (set in the admin). The "View More"
   // button opens the first available link in a new tab.
   const viewMoreLink = gallery.find((g) => g.link)?.link ?? null;
+
+  // Clicking a card opens it enlarged in a lightbox; Escape closes it (the
+  // backdrop click is handled on the overlay itself). Once open, the desktop
+  // arrows / arrow keys / mobile swipe move through the whole gallery list,
+  // wrapping at the ends. `direction` drives the slide animation: 0 = the
+  // open/close zoom, ±1 = slide in from the right/left.
+  const selectedImage = selected !== null ? gallery[selected] : null;
+  const hasMultiple = gallery.length > 1;
+  const [direction, setDirection] = useState(0);
+
+  const showPrev = useCallback(() => {
+    setDirection(-1);
+    setSelected((s) =>
+      s === null ? s : (s - 1 + gallery.length) % gallery.length
+    );
+  }, [gallery.length]);
+
+  const showNext = useCallback(() => {
+    setDirection(1);
+    setSelected((s) => (s === null ? s : (s + 1) % gallery.length));
+  }, [gallery.length]);
+
+  const closeLightbox = useCallback(() => {
+    setDirection(0);
+    setSelected(null);
+  }, []);
+
+  useEffect(() => {
+    if (selected === null) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeLightbox();
+      else if (e.key === "ArrowLeft") showPrev();
+      else if (e.key === "ArrowRight") showNext();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [selected, closeLightbox, showPrev, showNext]);
 
   if (!gallery.length) return null;
 
@@ -79,16 +118,26 @@ const GallerySection = () => {
                 offset={offset}
                 onHoverStart={() => setHovered(i)}
                 onHoverEnd={() => setHovered(null)}
-                onClick={() => setSelected(selected === i ? null : i)}
+                onClick={() => {
+                  setDirection(0);
+                  setSelected(i);
+                }}
               />
             );
           })}
         </div>
 
         <div className="flex justify-center mt-16">
+          {/* Same ghost "View more" button as the Major Highlights section */}
           <Button
-            label="View More"
-            rightIcon={<ChevronRight size={18} />}
+            className="flex items-center justify-center whitespace-nowrap"
+            rightIcon={
+              <div className="bg-[#3571F0] text-white px-1 py-1 rounded-full">
+                <ArrowRight size={15} strokeWidth={2} />
+              </div>
+            }
+            label="View more"
+            variant="ghost"
             disabled={!viewMoreLink}
             onClick={() => {
               if (viewMoreLink) {
@@ -98,6 +147,90 @@ const GallerySection = () => {
           />
         </div>
       </div>
+
+      {/* Lightbox: the clicked image enlarged over a dark backdrop. Clicking
+          anywhere outside the image (or Escape) closes it; the card is
+          deselected so it springs back to its slot in the stack. z-[100]
+          keeps it above the fixed navbar (z-50). */}
+      <AnimatePresence>
+        {selectedImage && (
+          <motion.div
+            className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4 sm:px-24 sm:py-10"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={closeLightbox}
+          >
+            {/* Keyed by image id so navigating swaps images with a
+                directional slide; direction 0 (open/close) falls back to the
+                original zoom in/out. popLayout takes the exiting image out of
+                flow so the incoming one is centered immediately. */}
+            <AnimatePresence initial={false} custom={direction} mode="popLayout">
+              <motion.img
+                key={selectedImage.id}
+                src={getImageUrl(selectedImage.imagePath)}
+                alt={`Gallery image ${(selected ?? 0) + 1} enlarged`}
+                className="max-w-full max-h-full rounded-[24px] md:rounded-[36px] object-contain shadow-2xl cursor-default"
+                custom={direction}
+                variants={{
+                  enter: (dir: number) =>
+                    dir === 0
+                      ? { x: 0, scale: 0.6, opacity: 0 }
+                      : { x: dir > 0 ? 300 : -300, scale: 1, opacity: 0 },
+                  center: { x: 0, scale: 1, opacity: 1 },
+                  exit: (dir: number) =>
+                    dir === 0
+                      ? { x: 0, scale: 0.6, opacity: 0 }
+                      : { x: dir > 0 ? -300 : 300, scale: 1, opacity: 0 },
+                }}
+                initial="enter"
+                animate="center"
+                exit="exit"
+                transition={{ type: "spring", stiffness: 240, damping: 22 }}
+                // Swipe left/right (mobile, and mouse-drag on desktop) to
+                // move between photos.
+                drag={hasMultiple ? "x" : false}
+                dragConstraints={{ left: 0, right: 0 }}
+                dragElastic={0.2}
+                onDragEnd={(_, info) => {
+                  if (info.offset.x < -80 || info.velocity.x < -500) showNext();
+                  else if (info.offset.x > 80 || info.velocity.x > 500)
+                    showPrev();
+                }}
+                onClick={(e) => e.stopPropagation()}
+              />
+            </AnimatePresence>
+
+            {hasMultiple && (
+              <>
+                <button
+                  type="button"
+                  aria-label="Previous image"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    showPrev();
+                  }}
+                  className="hidden sm:flex absolute left-4 md:left-8 top-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 p-2.5 text-gray-400 hover:text-white hover:bg-white/20 transition-colors"
+                >
+                  <ChevronLeft size={32} />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Next image"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    showNext();
+                  }}
+                  className="hidden sm:flex absolute right-4 md:right-8 top-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 p-2.5 text-gray-400 hover:text-white hover:bg-white/20 transition-colors"
+                >
+                  <ChevronRight size={32} />
+                </button>
+              </>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/client/pages/home/sections/highlight-section/HighlightSection.tsx
+++ b/src/client/pages/home/sections/highlight-section/HighlightSection.tsx
@@ -114,7 +114,13 @@ export default function HighlightSection() {
                 slidesPerView: 4,
               },
             }}
-            className="pb-16"
+            // The swiper clips at its own box (overflow: hidden), which used to
+            // slice the card drop-shadows off in a hard line at the edges. The
+            // padding gives the shadows room to fade out; the negative margins
+            // cancel it so the cards stay aligned with the section. Keep the
+            // padding smaller than spaceBetween (20px) or the neighbouring
+            // off-screen slide peeks in.
+            className="pb-16 !px-3 !-mx-3 !pt-2 !-mt-2"
           >
             {highlights.map((event, index) => (
               // !h-auto lets the flex slides stretch to the tallest card so every

--- a/src/client/pages/home/sections/speaker-section/SpeakerCard.tsx
+++ b/src/client/pages/home/sections/speaker-section/SpeakerCard.tsx
@@ -1,6 +1,11 @@
+import { Link } from "react-router-dom";
+import { CircleArrowRight } from "lucide-react";
 import Speakers from "./../../../../../assets/speaker-1.png";
 import type { Speaker } from "../../types";
 import { getImageUrl } from "../../../../../lib/imageUtils";
+import { slugify } from "../../../../../lib";
+import { useHome } from "../../useHome";
+import { useVersion } from "../../../../routes/VersionContext";
 
 interface SpeakerCardProps {
   speaker: Speaker;
@@ -21,6 +26,15 @@ const SpeakerCard = ({ speaker }: SpeakerCardProps) => {
   const instagram = normalizeUrl(speaker.socialLinks?.instagram);
   const portfolio = normalizeUrl(speaker.socialLinks?.portfolio);
   const linkedin = normalizeUrl(speaker.socialLinks?.linkedin);
+
+  const { getPath } = useVersion();
+  // The Speaker entity carries no event relation, but each highlight event
+  // lists its speakers — match by id to surface the speaker's related event.
+  const { data: relatedEvent } = useHome((d) =>
+    d.sections.highlights.find((event) =>
+      event.speakers?.some((s) => s.id === speaker.id)
+    )
+  );
 
   return (
     <div
@@ -60,19 +74,25 @@ const SpeakerCard = ({ speaker }: SpeakerCardProps) => {
             </span>
             <span className="text-xs text-[#BBC0CC]">{speaker.company}</span>
           </div>
-          {/* TODO(mapping): the talk topic ("AI in Finance") has no field on the
-              Speaker entity. Hardcoded for now — confirm where this comes from
-              (talk/session relation?) before wiring. */}
-          <div className="flex items-center gap-2 mt-1">
-            {/* <img src={Rightarrow} alt="Arrow" /> */}
-            <span className="text-[13px] font-semibold bg-gradient-to-r from-[#DBF5FF] to-[#51A7FF] bg-clip-text text-transparent">
-             
-            </span>
-          </div>
+          {relatedEvent && (
+            <Link
+              to={getPath(`/event-detail/${slugify(relatedEvent.title)}`)}
+              className="group relative z-20 flex items-center gap-2 mt-1"
+            >
+              <CircleArrowRight
+                size={18}
+                className="shrink-0 text-[#51A7FF] -rotate-45 transition-transform duration-700 group-hover:rotate-0"
+              />
+              <span className="text-left text-sm font-normal sm:font-medium font-primary bg-gradient-to-r from-[#DBF5FF] to-[#51A7FF] bg-clip-text text-transparent">
+                {relatedEvent.title}
+              </span>
+            </Link>
+          )}
         </div>
 
-        {/* Social Icons */}
-        <div className="flex gap-3 ">
+        {/* Social Icons — kept above the speaker photo (which is pulled up
+            over this row by its negative margin) so they stay clickable */}
+        <div className="relative z-20 flex gap-3 ">
           {instagram && (
             <a
               href={instagram}
@@ -166,7 +186,9 @@ const SpeakerCard = ({ speaker }: SpeakerCardProps) => {
         </div>
 
         {/* Speaker Image — sits naturally at the bottom */}
-        <div className="flex justify-end items-end flex-1 overflow-hidden mt-[-150px] sm:mt-[-120px]">
+        {/* -mr-2 cancels the wrapper's pr-2 so the photo touches the card's
+            right border */}
+        <div className="relative z-0 pointer-events-none flex justify-end items-end flex-1 overflow-hidden mt-[-150px] sm:mt-[-120px] -mr-2">
           <img
             src={speaker.imageUrl ? getImageUrl(speaker.imageUrl) : Speakers}
             alt={speaker.name}

--- a/src/client/pages/home/sections/sponser-section/SponserSection.tsx
+++ b/src/client/pages/home/sections/sponser-section/SponserSection.tsx
@@ -40,7 +40,7 @@ export default function SponserSection() {
                 <img
                   src={sponsor.imageUrl ? getImageUrl(sponsor.imageUrl) : undefined}
                   alt={sponsor.name}
-                  className="w-full h-full object-cover md:rounded-2xl"
+                  className="w-full h-full object-contain md:rounded-2xl"
                 />
               </motion.a>
             ))}


### PR DESCRIPTION
## Summary

Two commits from SaugatDev:

**Home page fixes (4526328)**
- Speaker card socials / related event fixes
- Sponsor logo fit
- Version rail
- Gallery lightbox

**Events page UI fixes (040c927)**
- Tightened gap between category tabs and event cards; more space above tabs and before the footer
- Mobile: gradient banner hidden, highlights swiper sits directly below the navbar, square slide corners, smaller pagination gap
- Load More now paginates 10 at a time and only shows when more events remain
- "All" tab lists events grouped by category displayOrder (workshops, then competitions, then sessions, etc.)
- Highlighted slides click through to their event detail page
- Highlights banner always shows all highlighted events regardless of the selected category tab
- Home highlights carousel no longer clips card drop-shadows at its edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)