### PR TITLE
Nav link visibility, group /team pricing, Sponsors load fix

### DIFF
--- a/src/client/components/card.tsx
+++ b/src/client/components/card.tsx
@@ -6,7 +6,7 @@ import { cn } from "../../shared/utils/cn";
 import { useVersion } from "../routes/VersionContext";
 import { getImageUrl } from "../../lib/imageUtils";
 import { goToRegistration } from "../../lib/registration";
-import { isRegistrationClosed } from "./event-card-format";
+import { isRegistrationClosed, formatEventPrice } from "./event-card-format";
 
 interface CardProps extends React.HTMLAttributes<HTMLElement> {
   item: ContentType;
@@ -81,7 +81,7 @@ const Card = ({ item, eventId, registerLink, className, ...rest }: CardProps) =>
           <div className="flex items-center gap-2 min-w-0">
             <Banknote className="w-4 h-4 text-[#10B981] shrink-0" />
             <span className="text-[#10B981] text-[12px] font-medium truncate">
-              {item.price > 0 ? `NPR ${item.price}` : "Free"}
+              {formatEventPrice(item.price, item.eventType)}
             </span>
           </div>
           <div className="flex items-center gap-2 min-w-0">

--- a/src/client/components/event-card-format.ts
+++ b/src/client/components/event-card-format.ts
@@ -56,6 +56,18 @@ export function formatEventDate(value: string | null | undefined): string {
   return `${weekday}, ${formatShortDate(value)}`;
 }
 
+/**
+ * Price label for an event card. Group events charge per team, so the amount
+ * gets a " /per Team" suffix; free/zero-fee events show "Free" (no suffix).
+ */
+export function formatEventPrice(
+  price: number,
+  eventType?: string | null,
+): string {
+  if (price <= 0) return "Free";
+  return eventType === "GROUP" ? `NPR ${price} /team` : `NPR ${price}`;
+}
+
 /** Builds "10:00 AM - 12:00 PM" (or just the start) from raw start/end times. */
 export function formatEventTimeRange(
   start: string | null | undefined,
@@ -98,6 +110,7 @@ export interface EventCardSource {
   bookedSeats: number;
   registrationDeadline?: string | null;
   speakers?: { id: string; name: string; imageUrl: string | null }[] | null;
+  eventType?: string | null;
 }
 
 /**
@@ -129,5 +142,6 @@ export function toEventCardItem(event: EventCardSource): ContentType {
     seats: remainingSeats(event),
     totalSeats: event.totalSeats,
     registrationDeadline: event.registrationDeadline ?? null,
+    eventType: event.eventType ?? null,
   };
 }

--- a/src/client/hooks/use-active-version-empty.ts
+++ b/src/client/hooks/use-active-version-empty.ts
@@ -1,0 +1,35 @@
+import { useApiQuery } from "../../lib";
+import { useVersionData } from "./use-version-data";
+
+interface PaginatedResult<T> {
+  items: T[];
+  meta: { total: number; page: number; limit: number };
+}
+
+interface Envelope<T> {
+  status: string;
+  message: string;
+  data: T;
+}
+
+/**
+ * True when the active (currently viewed) version has no team members to
+ * display. Drives hiding of the Teams nav item (navbar + footer) — mirrors how
+ * the Events link is hidden when there's nothing to show.
+ *
+ * Uses the same query key as the Teams page's default "all categories" fetch
+ * (`teamMembers` + versionId + limit 200) so it shares that cache instead of
+ * firing a second request. Returns false while loading so the link doesn't
+ * flash out and back in.
+ */
+export function useActiveVersionHasNoTeams(): boolean {
+  const { versionId } = useVersionData();
+  const { data, isLoading } = useApiQuery("teamMembers")<
+    Envelope<PaginatedResult<unknown>>
+  >({
+    queryParams: { versionId: versionId ?? undefined, limit: 200 },
+    enabled: !!versionId,
+  });
+  const count = data?.data?.items?.length ?? 0;
+  return !!versionId && !isLoading && count === 0;
+}

--- a/src/client/hooks/use-current-edition-empty.ts
+++ b/src/client/hooks/use-current-edition-empty.ts
@@ -1,0 +1,18 @@
+import { useHome } from "../pages/home/useHome";
+import { useEventsList } from "../pages/event/useEvents";
+
+/**
+ * True only when the edition being viewed IS the current one AND it has no
+ * published events. Drives hiding of the Events nav item (navbar + footer) and
+ * the landing-page "Register Now" CTA — there's nothing to browse or register
+ * for yet.
+ *
+ * Returns false while either query is still loading so links don't flash out
+ * and back in, and never affects past (non-current) editions, which keep their
+ * Events link regardless.
+ */
+export function useCurrentEditionHasNoEvents(): boolean {
+  const { data: isCurrent } = useHome((d) => d.edition.isCurrent);
+  const { events, isLoading } = useEventsList();
+  return isCurrent === true && !isLoading && events.length === 0;
+}

--- a/src/client/layouts/footer/Footer.tsx
+++ b/src/client/layouts/footer/Footer.tsx
@@ -8,6 +8,8 @@ import SectionContainer from "../../components/sectionContainer";
 import { useVersion } from "../../routes/VersionContext";
 import { useSiteSettings } from "../../hooks/use-site-settings";
 import { useHome } from "../../pages/home/useHome";
+import { useCurrentEditionHasNoEvents } from "../../hooks/use-current-edition-empty";
+import { useActiveVersionHasNoTeams } from "../../hooks/use-active-version-empty";
 
 export const Footer = () => {
   const navigate = useNavigate();
@@ -35,10 +37,16 @@ export const Footer = () => {
     (l) => l.platform.toLowerCase() === "linkedin",
   )?.link || "#";
 
+  // Drop the Events link when the current edition has no published events yet
+  // (mirrors the navbar). Past editions always keep it.
+  const hideEvents = useCurrentEditionHasNoEvents();
+  // Drop the Teams link when the active version has no team members.
+  const hideTeams = useActiveVersionHasNoTeams();
+
   const pages = [
     { path: "/", label: "Home" },
-    { path: "/events", label: "Events" },
-    { path: "/teams", label: "Teams" },
+    ...(hideEvents ? [] : [{ path: "/events", label: "Events" }]),
+    ...(hideTeams ? [] : [{ path: "/teams", label: "Teams" }]),
     { path: "/sponsors", label: "Sponsors" },
     { path: "/contacts", label: "Contacts" },
   ];

--- a/src/client/layouts/footer/Footer.tsx
+++ b/src/client/layouts/footer/Footer.tsx
@@ -41,8 +41,11 @@ export const Footer = () => {
     { path: "/teams", label: "Teams" },
     { path: "/sponsors", label: "Sponsors" },
     { path: "/contacts", label: "Contacts" },
-    { path: "/contributors", label: "Contributors" },
   ];
+
+  // Same external link in every version, so it isn't version-prefixed.
+  const contributorsLink =
+    "https://github.com/primeitclub/ict-meetup-contributers";
 
   return (
     <SectionContainer
@@ -246,6 +249,14 @@ export const Footer = () => {
               {label}
             </NavLink>
           ))}
+          <a
+            href={contributorsLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors duration-300 text-nav-default hover:text-nav-hover font-normal"
+          >
+            Contributors
+          </a>
         </nav>
 
         <button

--- a/src/client/layouts/headers/Navbar.tsx
+++ b/src/client/layouts/headers/Navbar.tsx
@@ -7,7 +7,8 @@ import SectionContainer from "../../components/sectionContainer";
 import { useVersion } from "../../routes/VersionContext";
 import { useVersions } from "../../hooks/use-versions";
 import { useHome } from "../../pages/home/useHome";
-import { useEventsList } from "../../pages/event/useEvents";
+import { useCurrentEditionHasNoEvents } from "../../hooks/use-current-edition-empty";
+import { useActiveVersionHasNoTeams } from "../../hooks/use-active-version-empty";
 
 const Navbar = () => {
   const { getPath, navigateToVersion, version } = useVersion();
@@ -24,12 +25,15 @@ const Navbar = () => {
   const { data: logo, isLoading: logoLoading } = useHome(
     (d) => d.edition.logoPath ?? d.edition.logo,
   );
-  const { events, isLoading: eventsLoading } = useEventsList();
   const versions = useVersions();
 
-  // Only surface the Events link when this edition actually has events.
-  // Keep it while loading to avoid a flash, hide it once confirmed empty.
-  const hasEvents = eventsLoading || events.length > 0;
+  // Hide the Events link only when the current edition has no published events
+  // yet (past editions always keep it). Stays visible while loading so it
+  // doesn't flash out and back in.
+  const hasEvents = !useCurrentEditionHasNoEvents();
+  // Hide the Teams link when the active version has no team members. Same
+  // flash-avoidance: shown while loading, hidden once confirmed empty.
+  const hasTeams = !useActiveVersionHasNoTeams();
 
   // Set by a same-page nav-item click in the mobile menu: the scroll-lock
   // cleanup below normally restores the pre-open scroll position on close,
@@ -79,7 +83,7 @@ const Navbar = () => {
   const pages = [
     { path: "/", label: "Home" },
     ...(hasEvents ? [{ path: "/events", label: "Events" }] : []),
-    { path: "/teams", label: "Teams" },
+    ...(hasTeams ? [{ path: "/teams", label: "Teams" }] : []),
     { path: "/sponsors", label: "Sponsors" },
     { path: "/contacts", label: "Contacts" },
   ];

--- a/src/client/pages/event-detail/components/EventDetailBanner.tsx
+++ b/src/client/pages/event-detail/components/EventDetailBanner.tsx
@@ -61,7 +61,9 @@ export const EventDetailBanner = ({ event }: EventDetailBannerProps) => {
             <div className="flex items-center gap-2 text-white text-base md:text-xl">
               <Banknote className="w-5 h-5 text-[#10B981] shrink-0" />
               <span>
-                {event.feeType === "free" ? "Free" : `NPR ${event.fee}`}
+                {event.feeType === "free"
+                  ? "Free"
+                  : `NPR ${event.fee}${event.eventType === "GROUP" ? " /team" : ""}`}
               </span>
             </div>
 

--- a/src/client/pages/event-detail/useEventDetail.ts
+++ b/src/client/pages/event-detail/useEventDetail.ts
@@ -17,6 +17,8 @@ export interface EventDetailData {
   status: string;
   registrationDeadline: string | null;
   category: { id: string; name: string; displayName: string };
+  /** "GROUP" events charge per team, so their fee shows "/team". */
+  eventType?: "SINGLE" | "GROUP" | null;
   speakers?: EventDetailSpeaker[] | null;
   /** External registration URL; takes precedence over the in-app form. */
   registerLink: string | null;

--- a/src/client/pages/event/EventPage.tsx
+++ b/src/client/pages/event/EventPage.tsx
@@ -25,6 +25,14 @@ export default function EventsPage() {
     setVisibleCount(PAGE_SIZE);
   };
 
+  // Only show category tabs that actually have at least one event in the
+  // current version. allEvents is the unfiltered, version-scoped list, so the
+  // set of category ids present there is exactly the categories to display.
+  const categoryIdsWithEvents = new Set(allEvents.map((e) => e.categoryId));
+  const visibleCategories = categories.filter((c) =>
+    categoryIdsWithEvents.has(c.id),
+  );
+
   const highlightedEvents = allEvents.filter((e) => e.isHighlighted);
   const visibleEvents = events.slice(0, visibleCount);
   const hasMore = events.length > visibleCount;
@@ -35,7 +43,7 @@ export default function EventsPage() {
       <div className="bg-[#F2F5FA] text-black">
         <div className="mx-auto max-w-7xl px-4 pt-2 pb-12 sm:pt-12 md:pb-24 md:space-y-10 space-y-12">
           <CategoryTabs
-            categories={categories}
+            categories={visibleCategories}
             activeCategoryId={activeCategoryId}
             onSelect={handleCategorySelect}
             isLoading={categoriesLoading}

--- a/src/client/pages/event/components/EventListItem.tsx
+++ b/src/client/pages/event/components/EventListItem.tsx
@@ -6,6 +6,7 @@ import { goToRegistration } from "../../../../lib/registration";
 import {
   isRegistrationClosed,
   toEventCardItem,
+  formatEventPrice,
 } from "../../../components/event-card-format";
 import type { ApiEvent } from "../useEvents";
 
@@ -60,7 +61,7 @@ const EventListItem = ({ event }: EventListItemProps) => {
             <div className="flex shrink-0 items-center gap-1.5">
               <Banknote className="h-3.5 w-3.5 text-[#10B981]" />
               <span className="text-[12px] font-semibold text-[#10B981]">
-                {item.price > 0 ? `NPR ${item.price}` : "Free"}
+                {formatEventPrice(item.price, item.eventType)}
               </span>
             </div>
           </div>

--- a/src/client/pages/home/sections/highlight-section/types/index.ts
+++ b/src/client/pages/home/sections/highlight-section/types/index.ts
@@ -11,6 +11,7 @@ export type ContentType = {
   seats: number;
   totalSeats: number;
   registrationDeadline?: string | null;
+  eventType?: string | null;
 };
 
 export type TabType = {

--- a/src/client/pages/home/sections/landing-section/LandingSection.tsx
+++ b/src/client/pages/home/sections/landing-section/LandingSection.tsx
@@ -8,6 +8,7 @@ import image from "../../../../../../public/ICT Meet/Arc-1.png"
 import { useHome } from "../../useHome";
 import { Link } from "react-router-dom";
 import { useVersion } from "../../../../routes/VersionContext";
+import { useCurrentEditionHasNoEvents } from "../../../../hooks/use-current-edition-empty";
 
 function formatEventDateRange(startDate?: string | null, endDate?: string | null): string {
   if (!startDate || !endDate) return "";
@@ -30,6 +31,8 @@ export function LandingSection() {
   const { data: edition } = useHome((d) => d.edition);
   const { data: hero } = useHome((d) => d.sections.hero);
   const dateLabel = formatEventDateRange(edition?.startDate, edition?.endDate);
+  // No events in the current edition → nothing to register for, so drop the CTA.
+  const hideRegister = useCurrentEditionHasNoEvents();
 
   return (
     <div className="landing_section relative w-full sm:min-h-screen pt-32 sm:pt-40 pb-[calc(32vw+56px)] sm:pb-0">
@@ -96,31 +99,33 @@ export function LandingSection() {
           </div> */}
         </div>
         <div className="flex sm:flex-row flex-col gap-4 sm:gap-10 items-center justify-center  pt-2 sm:pt-10">
-          <Link to={getPath("/register")}>
-            {/* Old glass button, but the whitish hover fill is kept ON always
-                (!bg-glow-secondary + black text) so Register Now stays the light
-                primary CTA. Wrapper scales up on hover only (no idle pulse). */}
-            <motion.div
-              className="inline-block"
-              whileHover={{ scale: 1.05 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
-            >
-              <Button
-                variant="glass"
-                className="!w-fit text-xs sm:text-base !bg-glow-secondary !text-black"
-                rightIcon={
-                  <motion.span
-                    className="flex"
-                    animate={{ x: [0, 4, 0] }}
-                    transition={{ duration: 1.2, ease: "easeInOut", repeat: Infinity }}
-                  >
-                    <ChevronRight />
-                  </motion.span>
-                }
-                label="Register Now "
-              />
-            </motion.div>
-          </Link>
+          {!hideRegister && (
+            <Link to={getPath("/register")}>
+              {/* Old glass button, but the whitish hover fill is kept ON always
+                  (!bg-glow-secondary + black text) so Register Now stays the light
+                  primary CTA. Wrapper scales up on hover only (no idle pulse). */}
+              <motion.div
+                className="inline-block"
+                whileHover={{ scale: 1.05 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
+              >
+                <Button
+                  variant="glass"
+                  className="!w-fit text-xs sm:text-base !bg-glow-secondary !text-black"
+                  rightIcon={
+                    <motion.span
+                      className="flex"
+                      animate={{ x: [0, 4, 0] }}
+                      transition={{ duration: 1.2, ease: "easeInOut", repeat: Infinity }}
+                    >
+                      <ChevronRight />
+                    </motion.span>
+                  }
+                  label="Register Now "
+                />
+              </motion.div>
+            </Link>
+          )}
           <Link to={getPath("/sponsors")}>
             <motion.div
               className="inline-block"

--- a/src/client/pages/home/types.ts
+++ b/src/client/pages/home/types.ts
@@ -93,6 +93,8 @@ export interface HighlightItem {
   categoryId: string;
   /** Speakers for this event; used for the "with <names>" line + avatars. */
   speakers?: { id: string; name: string; imageUrl: string | null }[] | null;
+  /** "GROUP" events charge per team, so their card price shows "/per Team". */
+  eventType?: "SINGLE" | "GROUP" | null;
   /** External registration URL; takes precedence over the in-app form. */
   registerLink: string | null;
 }

--- a/src/client/pages/register/PaymentSuccess.tsx
+++ b/src/client/pages/register/PaymentSuccess.tsx
@@ -112,7 +112,10 @@ const PaymentSuccess = () => {
 
   const getPrice = () => {
     if (!eventDetail) return "Free";
-    return eventDetail.feeType === "free" ? "Free" : `NPR ${eventDetail.fee}`;
+    if (eventDetail.feeType === "free") return "Free";
+    // Group events are priced per team, so surface that on the amount.
+    const suffix = eventDetail.eventType === "GROUP" ? " /team" : "";
+    return `NPR ${eventDetail.fee}${suffix}`;
   };
 
   if (isLoading) {

--- a/src/client/pages/sponsors/Sponsors.tsx
+++ b/src/client/pages/sponsors/Sponsors.tsx
@@ -61,11 +61,14 @@ const Sponsors = () => {
     enabled: !!versionId,
   });
 
-  const { data: contactsRes, isLoading: contactsLoading } = useApiQuery(
+  const { data: contactsRes } = useApiQuery(
     "settingsContacts",
   )<Envelope<ContactSettings>>({
     queryParams: { versionId: versionId ?? undefined },
     enabled: !!versionId,
+    // Only feeds the optional "Join Our Sponsors" card (which falls back to
+    // siteSettings), so don't let a slow/failing endpoint retry for ~7s.
+    config: { retry: 1 },
   });
   const { data: siteSettings } = useSiteSettings();
 
@@ -73,7 +76,9 @@ const Sponsors = () => {
     (a, b) => a.displayOrder - b.displayOrder,
   );
   const sponsors = sponsorsRes?.data?.items ?? [];
-  const isLoading = versionLoading || categoriesLoading || sponsorsLoading || contactsLoading;
+  // Contacts intentionally excluded: it only populates the optional contact
+  // card, so it must not block the whole page from rendering.
+  const isLoading = versionLoading || categoriesLoading || sponsorsLoading;
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
Navbar/footer link visibility, group-event pricing, and a Sponsors page load fix.

### Changes
- **Group event pricing** — events with `eventType === "GROUP"` show the amount with a `/team` suffix (e.g. `NPR 500 /team`) in the events card, event-detail banner, and payment success page. Free events are unchanged.
- **Contributors link** — footer "Contributors" now points to `https://github.com/primeitclub/ict-meetup-contributers` (external, identical across all versions).
- **Hide empty Events link** — the Events nav item (navbar + footer) and the landing "Register Now" CTA are hidden when the current edition has no published events.
- **Hide empty Teams link** — the Teams nav item (navbar + footer) is hidden when the active version has no team members.
- **Sponsors load fix** — the Sponsors page no longer blocks rendering on the contacts query, which could stall ~5-6s on a slow/failing endpoint; the contacts query is capped at `retry: 1`.

## Test plan
- `yarn build` passes.
- Verified against the live backend: highlight/team/event counts drive the correct show/hide behavior per edition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
