### PR TITLE
feat(event-detail): render event description as markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "framer-motion": "^12.34.0",
     "gsap": "^3.14.2",
     "lucide-react": "^0.562.0",
+    "marked": "^18.0.6",
     "motion": "^12.36.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",

--- a/src/client/pages/event-detail/components/EventOverview.tsx
+++ b/src/client/pages/event-detail/components/EventOverview.tsx
@@ -1,4 +1,6 @@
+import { marked } from "marked";
 import { formatEventDate, formatEventTime } from "../../../components/event-card-format";
+import RichText from "../../../../shared/design-components/rich-text/RichText";
 import type { EventDetailData } from "../useEventDetail";
 
 interface EventsOverviewProps {
@@ -6,9 +8,16 @@ interface EventsOverviewProps {
 }
 
 export const EventsOverview = ({ event }: EventsOverviewProps) => {
+  // The description is authored as markdown in the admin. Parse it to HTML,
+  // then hand it to RichText (DOMPurify) — the app's single trusted HTML
+  // render path — rather than dumping the raw markdown source into a <p>.
+  const descriptionHtml = event.description
+    ? (marked.parse(event.description) as string)
+    : "";
+
   return (
     <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-1 text-base text-[#2d2d2d]">
           {event.startTime && (
             <p>
@@ -30,9 +39,10 @@ export const EventsOverview = ({ event }: EventsOverviewProps) => {
             <span className="font-medium">Total Seats:</span> {event.totalSeats}
           </p>
         </div>
-        <p className="text-base text-gray-700 leading-relaxed text-justify">
-          {event.description}
-        </p>
+        <RichText
+          html={descriptionHtml}
+          className="text-base text-gray-700 leading-relaxed text-justify [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:mb-3 [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:mt-5 [&_h1]:mb-2 [&_h2]:text-xl [&_h2]:font-bold [&_h2]:mt-5 [&_h2]:mb-2 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:mt-4 [&_h3]:mb-1.5 [&_strong]:font-semibold [&_em]:italic [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:mb-3 [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:mb-3 [&_li]:mb-1 [&_a]:text-accent [&_a]:underline [&_blockquote]:border-l-4 [&_blockquote]:border-gray-300 [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:mb-3 [&_code]:rounded [&_code]:bg-gray-100 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-sm"
+        />
       </div>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,6 +2535,11 @@ lucide-react@^0.562.0:
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.562.0.tgz#217796c2f57624f012b484ea7f08505067c90d51"
   integrity sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==
 
+marked@^18.0.6:
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-18.0.6.tgz#7faf26fd580b9c8daa75984f18db25631fc4ad63"
+  integrity sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==
+
 memoize-one@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"


### PR DESCRIPTION
## What
Render the event description as **markdown** on the event-detail page.

- Parse the stored markdown with `marked`, then render through the sanitizing `RichText` (DOMPurify) component — the app's single trusted HTML render path — instead of showing raw markdown source in a `<p>`.
- Add tailored typography spacing so headings sit close to their paragraphs and blocks are evenly spaced.
- Add `marked` dependency (yarn).

## Why
Pairs with the admin change that authors the event description in a markdown editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)